### PR TITLE
feat(api): signalement chapitres + historique + traductions serveur + catalogue nightly

### DIFF
--- a/.claude/memory-bank/decisions.md
+++ b/.claude/memory-bank/decisions.md
@@ -1,6 +1,6 @@
 # Décisions Architecturales — Manga Tracker API
 
-**Dernière mise à jour :** Mai 2026
+**Dernière mise à jour :** Juillet 2026
 
 ---
 
@@ -69,6 +69,18 @@
 **Raison** : Le front Flutter cible Android (actuel), iOS et Web à venir. La whitelist doit anticiper le domaine web futur.
 **Impact** : Variable `CORS_ORIGINS` (séparée par virgules) consommée dans `main.ts`. Mise à jour de la whitelist quand le domaine web sera décidé.
 **Date** : 2026-05 (évolution sécurité)
+
+---
+
+### total_chapters : écriture GREATEST inconditionnelle (anti-régression)
+**Décision** : Toute écriture de `manga.total_chapters` depuis MangaUpdates passe par `GREATEST(total_chapters, :newTotal)` — `MangasService.getMangaDetails`, `LibraryService.checkManga` (refresh 6h) et `ChapterReportService.consolidate` — **y compris quand MU annonce `completed = true` avec un total plus bas**.
+**Raison** :
+- Le total MU est extrait par regex sur le champ `status` → peu fiable (baisses fantômes constatées).
+- `sync-manga.service.ts` faisait déjà `Math.max` : on généralise l'invariant au lieu d'avoir deux comportements.
+- Un user avec `user_read_chapters = 90` prouve que le total réel ≥ 90 — une régression re-bloquerait sa progression (bug du cap 406).
+- Le chantier « signalement chapitres » (`manga_chapter_report`) repose sur des totaux **monotones croissants** pour que consolidation et refresh 6h convergent sans lock.
+**Impact** : une baisse légitime côté MU (correction éditoriale, très rare) ne redescend jamais automatiquement → correction manuelle en BDD assumée. `completed` reste écrasé par MU à chaque refresh (seul `total_chapters` est monotone).
+**Date** : 2026-07 (chantiers signalement chapitres + historique de lecture)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format : [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/) · Versioning 
 
 ---
 
+## [Unreleased] — feat/recos-chapitres-traductions
+
+### Added
+- **library** : `POST /library/:muId/report-chapters` — signalement « plus de chapitres » par user (Chantier A) : upsert `manga_chapter_report`, total effectif = `max(total officiel, reported_total)`, consolidation communautaire ≥ 2 users distincts (MIN des concordants, écriture GREATEST sur `manga.total_chapters`)
+
+### Changed
+- **library** : `PUT /library/chapter` — cap 406 s'applique au total effectif `max(total_chapters, report user)` et non plus au total officiel seul ; backfill transactionnel du journal `user_manga_chapter_log` (chapitres oldRead+1..newRead, cap 500 derniers, dédup 10 min du chapitre terminal, décrément = no-op) dans la même transaction que le pointeur (fallback séquentiel best-effort)
+- **library** : `GET /library/all` — `totalChapters` expose le total effectif + nouveau champ optionnel `userReportedTotalChapters` dans `MangaQuickViewDto`
+- **library / mangas** : écriture GREATEST inconditionnelle sur `manga.total_chapters` dans `checkManga` (refresh 6 h) ET `getMangaDetails` (invariant A-5 : monotone croissant, la regex MU sous-estime le vrai total — voir memory-bank/decisions.md)
+- **library** : `POST /library/:muId/chapter-log` — fenêtre d'idempotence 10 min : une lecture identique (user, manga, chapitre, non-skippée) < 10 min réutilise la ligne existante
+
+### BDD
+- Migration `1753100000000-CreateMangaChapterReport` : nouvelle table `manga_chapter_report` (FK user CASCADE + manga CASCADE, index unique `(user_id, manga_id)`, index `manga_id`)
+
+---
+
 ## [Unreleased] — sprint hotfix-v0-10-1
 
 ### Added

--- a/docs/specs/library/spec-technique.md
+++ b/docs/specs/library/spec-technique.md
@@ -1,20 +1,21 @@
 # Spec Technique — Library
 
-| Champ         | Valeur              |
-|---------------|---------------------|
-| Module        | library             |
-| Version       | 0.1.0               |
-| Date          | 2026-06-04          |
-| Source        | Rétro-ingénierie    |
+| Champ         | Valeur                            |
+|---------------|-----------------------------------|
+| Module        | library                           |
+| Version       | 0.2.0                             |
+| Date          | 2026-07-20                        |
+| Source        | Rétro-ingénierie + Chantier A     |
 
 ## Architecture du module
 
-Le module Library est structuré en deux services distincts montés dans un seul `LibraryModule` :
+Le module Library est structuré en trois services distincts montés dans un seul `LibraryModule` :
 
-- **LibraryService** : gère le CRUD de la collection (`UserManga`) — ajout, suppression, mise à jour du compteur de chapitres, du statut, du lien personnalisé et de la note. Orchestre également la vérification / création à la volée des entités `Manga` (via `MangasService`).
-- **ChapterLogService** : gère le log additif de sessions de lecture (`UserMangaChapterLog`) — insertion de sessions, liste historique, toggle skip. Complètement découplé du compteur principal géré par `LibraryService`.
+- **LibraryService** : gère le CRUD de la collection (`UserManga`) — ajout, suppression, mise à jour du compteur de chapitres (avec backfill transactionnel du journal), du statut, du lien personnalisé et de la note. Orchestre également la vérification / création à la volée des entités `Manga` (via `MangasService`). Depuis Chantier A : le cap 406 s'applique au total *effectif* (`max(total_chapters, report user)`).
+- **ChapterLogService** : gère le log additif de sessions de lecture (`UserMangaChapterLog`) — insertion de sessions avec déduplication 10 min, liste historique, toggle skip, backfill multi-rows capé à 500 lignes.
+- **ChapterReportService** (Chantier A) : gère le signalement « plus de chapitres » (`MangaChapterReport`) — upsert par user, calcul du total effectif, consolidation communautaire (MIN des concordants dès 2 users distincts, écriture GREATEST), purge lazy.
 
-Les deux services sont exposés par un seul `LibraryController`. Toutes les routes sont protégées par `JwtAuthGuard`. L'utilisateur courant est extrait du token via `@UserDecorator()`.
+Les routes sont exposées par deux controllers : `LibraryController` (collection + chapter-log) et `ChapterReportController` (sous-controller dédié au signalement, même préfixe `library` — `LibraryController` dépassait déjà la limite de 200 lignes). Toutes les routes sont protégées par `JwtAuthGuard`. L'utilisateur courant est extrait du token via `@UserDecorator()`.
 
 Une dépendance circulaire avec `MangasModule` est résolue par `forwardRef(() => MangasModule)` dans les imports du module.
 
@@ -22,9 +23,12 @@ Une dépendance circulaire avec `MangasModule` est résolue par `forwardRef(() =
 
 | Fichier | Rôle | Lignes |
 |---------|------|--------|
-| `src/api/library/library.controller.ts` | Routes HTTP (10 endpoints) | ~252 |
-| `src/api/library/library.service.ts` | Logique métier collection (CRUD UserManga, validation) | ~297 |
-| `src/api/library/chapter-log.service.ts` | Logique log additif de lecture (Phase 5) | ~115 |
+| `src/api/library/library.controller.ts` | Routes HTTP (10 endpoints) | ~254 |
+| `src/api/library/chapter-report.controller.ts` | Route HTTP signalement chapitres (Chantier A) | ~73 |
+| `src/api/library/library.service.ts` | Logique métier collection (CRUD UserManga, backfill transactionnel) | ~399 |
+| `src/api/library/chapter-log.service.ts` | Log additif de lecture — backfill capé 500, dédup 10 min | ~228 |
+| `src/api/library/chapter-report.service.ts` | Signalement chapitres + consolidation communautaire (Chantier A) | ~228 |
+| `src/api/library/manga-chapter-report.entity.ts` | Entité TypeORM table `manga_chapter_report` (Chantier A) | ~54 |
 | `src/api/library/library.module.ts` | Déclaration du module NestJS | ~26 |
 | `src/api/library/reading-status.enum.ts` | Enum ReadingStatus + helpers | ~14 |
 | `src/api/library/user-manga-chapter-log.entity.ts` | Entité TypeORM table `user_manga_chapter_log` | ~77 |
@@ -35,8 +39,10 @@ Une dépendance circulaire avec `MangasModule` est résolue par `forwardRef(() =
 | `src/api/library/dto/update-custom-link.dto.ts` | DTO lien personnalisé | ~13 |
 | `src/api/library/dto/update-rating.dto.ts` | DTO note personnelle | ~13 |
 | `src/api/library/dto/chapter-log.dto.ts` | DTOs log de lecture (RecordChapterLogDto, ToggleChapterSkipDto, ChapterLogEntryDto) | ~80 |
+| `src/api/library/dto/report-chapters.dto.ts` | DTOs signalement chapitres (ReportChaptersDto, ReportChaptersResultDto) | ~45 |
 | `src/api/library/exceptions/chapter.exception.ts` | Exception HTTP 406 pour chapitre invalide | ~7 |
 | `src/api/library/exceptions/reading-status.exception.ts` | Exception HTTP 406 pour statut invalide | ~7 |
+| `src/migrations/1753100000000-CreateMangaChapterReport.ts` | Migration création table `manga_chapter_report` | ~88 |
 
 ## Schéma BDD
 
@@ -69,11 +75,28 @@ Une dépendance circulaire avec `MangasModule` est résolue par `forwardRef(() =
 
 Index composite : `(user_id, manga_id, chapterNumber)` sur `user_manga_chapter_log`.
 
+### Table `manga_chapter_report` (Chantier A)
+
+| Colonne | Type | Contraintes | Description |
+|---------|------|-------------|-------------|
+| `id` | int PK | auto-increment | Identifiant interne |
+| `user_id` | int FK | NOT NULL, CASCADE DELETE | Référence `user.id` |
+| `manga_id` | bigint FK | NOT NULL, CASCADE DELETE | Référence `manga.mu_id` |
+| `reported_total` | int | NOT NULL | Total de chapitres signalé par l'user (> total officiel) |
+| `created_at` | timestamp | NOT NULL, default CURRENT_TIMESTAMP | Horodatage de création |
+| `updated_at` | timestamp | NOT NULL, default CURRENT_TIMESTAMP | Horodatage de dernière modification |
+
+Contrainte d'unicité : `UQ_chapter_report_user_manga (user_id, manga_id)` — un report actif par user et par manga (upsert `ON CONFLICT DO UPDATE`).
+Index supplémentaire : `IDX_chapter_report_manga (manga_id)` — couvre la requête de consolidation.
+
+**Invariant** : `reported_total > manga.total_chapters` à l'écriture. Le total effectif pour un user est `max(manga.total_chapters, reported_total)`. Quand le total officiel rattrape ou dépasse le report, la ligne est purgée (purge lazy dans `getEffectiveTotal`).
+
 ### Relations
 
 - `UserManga` : ManyToOne vers `User`, ManyToOne vers `Manga` (clé `manga_id` → `manga.mu_id`)
 - `UserMangaChapterLog` : ManyToOne vers `User`, ManyToOne vers `Manga` (clé `manga_id` → `manga.mu_id`)
-- Les deux tables ont `onDelete: 'CASCADE'` sur les deux FK
+- `MangaChapterReport` : ManyToOne vers `User`, ManyToOne vers `Manga` (clé `manga_id` → `manga.mu_id`, type bigint)
+- Les trois tables ont `onDelete: 'CASCADE'` sur les deux FK
 
 ## API / Endpoints
 
@@ -90,14 +113,17 @@ Index composite : `(user_id, manga_id, chapterNumber)` sur `user_manga_chapter_l
 | `POST` | `/library/:muId/chapter-log` | Enregistrer une session de lecture | JWT | 201 `ChapterLogEntryDto` |
 | `GET` | `/library/:muId/chapter-log` | Historique des sessions de lecture | JWT | 200 `ChapterLogEntryDto[]` |
 | `PUT` | `/library/:muId/chapter/:chapterNumber/skip` | Toggle skip/unskip d'un chapitre | JWT | 200 `ChapterLogEntryDto` |
+| `POST` | `/library/:muId/report-chapters` | Signaler un total de chapitres plus élevé que le total officiel (Chantier A, throttle 10/h) | JWT | 201 `ReportChaptersResultDto` |
 
 ### Codes d'erreur spécifiques
 
 | Code | Exception | Déclencheur |
 |------|-----------|-------------|
 | 400 | `BadRequestException` | Manga déjà présent dans la bibliothèque |
-| 404 | `NotFoundException` | User ou manga introuvable |
-| 406 | `ChapterException` | `readChapters > total_chapters` |
+| 400 | `BadRequestException` | `reportedTotal <= total_chapters` (report-chapters : doit être strictement supérieur) |
+| 400 | `BadRequestException` | `reportedTotal > total_chapters + 200` (report-chapters : garde-fou anti-typo MAX_REPORT_DELTA) |
+| 404 | `NotFoundException` | User, manga introuvable, ou manga absent de la bibliothèque de l'user (report-chapters) |
+| 406 | `ChapterException` | `readChapters > effectiveTotal` (total effectif = max(total officiel, report user)) |
 | 406 | `ReadingStatusException` | Valeur de statut non reconnue |
 | 409 | `ConflictException` | Doublons `UserManga` en base (anomalie) |
 
@@ -114,26 +140,34 @@ Note : un statut `dropped` (abandonné) est mentionné dans le contexte discover
 
 ## Patterns identifiés
 
-- **Service layer strict** : `LibraryController` ne contient aucune logique métier — tout est délégué à `LibraryService` ou `ChapterLogService`.
-- **Repository pattern via TypeORM** : les repositories `UserManga`, `User`, `Manga`, `UserMangaChapterLog` sont injectés par `@InjectRepository()`.
-- **QueryBuilder pour les mises à jour** : les updates (`updateChapter`, `updateReadingStatus`) utilisent `createQueryBuilder().update()` plutôt que `save()` pour des raisons de performance.
+- **Service layer strict** : `LibraryController` ne contient aucune logique métier — tout est délégué à `LibraryService`, `ChapterLogService` ou `ChapterReportService`.
+- **Repository pattern via TypeORM** : les repositories `UserManga`, `User`, `Manga`, `UserMangaChapterLog`, `MangaChapterReport` sont injectés par `@InjectRepository()`.
+- **QueryBuilder pour les mises à jour** : les updates (`updateChapter`, `updateReadingStatus`, `consolidate`) utilisent `createQueryBuilder().update()` plutôt que `save()` pour des raisons de performance.
 - **Stateless computation du statut** : le statut de lecture est calculé à la volée dans `updateChapter` sans colonne computée en base.
 - **Fire-and-forget pour les rafraîchissements** : `checkIfMangaArrayInfoIsOutdated` est appelé sans `await` dans `getMangas`, avec capture des erreurs via `.catch()`.
 - **Upsert manuel pour le toggle skip** : `ChapterLogService.toggleSkip` implémente un upsert manuellement (find + update ou create) car TypeORM ne propose pas d'upsert conditionnel natif adapté.
+- **Upsert `ON CONFLICT DO UPDATE` pour les reports** : `ChapterReportService.reportMoreChapters` utilise `createQueryBuilder().insert().orUpdate()` sur les colonnes `['reported_total', 'updated_at']` conflitant sur `['user_id', 'manga_id']` (index unique `UQ_chapter_report_user_manga`).
 - **Création à la volée des entités Manga** : dans `checkManga`, si un manga n'est pas en base, il est créé par appel à l'API MangaUpdates. Ce side-effect est encapsulé dans la méthode privée `checkManga`.
 - **`NotFoundInterceptor`** : `POST /library/save` utilise un intercepteur global pour transformer les `NotFoundException` en réponses propres.
 - **Deux sources de vérité intentionnellement distinctes** : `user_manga.user_read_chapters` (pointeur de progression) et `user_manga_chapter_log` (historique additif) coexistent sans synchronisation. Le log ne met jamais à jour le compteur — c'est une séparation de responsabilité explicite documentée dans les commentaires du code.
+- **GREATEST monotone sur `total_chapters` (invariant A-5)** : tout write sur `manga.total_chapters` — que ce soit dans `checkManga` (refresh MangaUpdates 6 h) ou dans `ChapterReportService.consolidate` (bump communautaire) — utilise `GREATEST(total_chapters, :newTotal)`. La colonne ne régresse jamais. Justification : la regex de parsing du status MangaUpdates sous-estime fréquemment le vrai total ; un total descendant casserait silencieusement la validation cap 406 pour les users ayant déjà progressé.
+- **Backfill transactionnel du journal** : `LibraryService.persistChapterProgress` exécute dans une même transaction TypeORM (`dataSource.transaction`, **première utilisation d'`@InjectDataSource` + transaction explicite du repo** — à surveiller au premier déploiement avec `migrationsRun` prod) l'UPDATE du pointeur `user_read_chapters` ET les INSERT multi-rows du backfill `ChapterLogService.recordBackfill`. Fallback séquentiel best-effort si la transaction échoue : UPDATE du pointeur seul (le pointeur prime), puis backfill dans un try/catch `logger.warn`.
+- **Consolidation communautaire conservatrice** : `ChapterReportService.consolidate` bumpe `manga.total_chapters` au MIN (pas au MAX) des totaux signalés concordants par ≥ 2 users distincts. Choix conservateur pour limiter l'impact d'un report erroné isolé.
 
 ## Configuration notable
 
 - **Seuil de rafraîchissement des métadonnées** : 6 heures (21 600 000 ms) codé en dur dans `LibraryService.checkManga`.
 - **Plafond de pagination du log** : 500 entrées codé en dur dans `ChapterLogService.listForManga` (commentaire "pagination future si besoin").
 - **`forwardRef`** : dépendance circulaire entre `LibraryModule` et `MangasModule` résolue par `forwardRef`.
+- **`BACKFILL_CAP = 500`** (constante `ChapterLogService`) : au-delà de 500 chapitres de delta en un seul PUT, seuls les 500 derniers sont journalisés. Le pointeur `user_read_chapters`, lui, n'est pas capé.
+- **`DEDUP_WINDOW_MINUTES = 10`** (constante `ChapterLogService`) : fenêtre d'idempotence — une lecture non-skippée du même chapitre plus récente que 10 min n'est pas dupliquée dans le backfill (évite le doublon reader + backfill `updateChapter`).
+- **`MAX_REPORT_DELTA = 200`** (constante `ChapterReportService`) : garde-fou anti-typo sur les reports — le total signalé ne peut pas dépasser le total officiel + 200.
+- **`MIN_REPORTERS = 2`** (constante `ChapterReportService`) : nombre minimum d'utilisateurs distincts concordants pour déclencher une consolidation communautaire du total officiel.
 
 ## Tests existants
 
 | Fichier | Ce qu'il teste | Statut |
 |---------|---------------|--------|
-| *(aucun)* | — | Absent |
-
-Aucun fichier `*.spec.ts` n'a été trouvé dans `src/api/library/`. Le module n'est pas couvert par des tests unitaires automatisés.
+| `src/api/library/chapter-report.service.spec.ts` | Validations 400/404, upsert, consolidation (1 vs 2 users, purge ≤ newTotal), purge lazy `getEffectiveTotal`, batch IN | ✅ |
+| `src/api/library/library.service.spec.ts` | `updateChapter` : 406 au-delà du total effectif, statuts Reading/CaughtUp/Completed, backfill transactionnel, décrément no-op, fallback séquentiel ; `checkManga` GREATEST ; `getMangas` exposition reports | ✅ |
+| `src/api/library/chapter-log.service.spec.ts` | Fenêtre de dédup 10 min (réutilise / nouvelle ligne), backfill multi-rows, cap 500 (derniers), dédup chapitre terminal, no-op décrément, variante EntityManager | ✅ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/jwt": "^10.0.3",
         "@nestjs/passport": "^9.0.3",
         "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/schedule": "^3.0.4",
         "@nestjs/swagger": "^6.3.0",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^9.0.1",
@@ -2159,6 +2160,35 @@
         "@nestjs/core": "^9.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-3.0.4.tgz",
+      "integrity": "sha512-uFJpuZsXfpvgx2y7/KrIZW9e1L68TLiwRodZ6+Gc8xqQiHSUzAVn+9F4YMxWFlHITZvvkjWziUFgRNCitDcTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "2.4.3",
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
+    "node_modules/@nestjs/schedule/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-9.1.0.tgz",
@@ -2642,6 +2672,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.8.tgz",
+      "integrity": "sha512-jYvz8UMLDgy3a5SkGJne8H7VA7zPV2Lwohjx0V8V31+SqAjNmurWMkk9cQhfvlcnXWudBpK9xPM1n4rljOcHYQ==",
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -4492,6 +4528,16 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-2.4.3.tgz",
+      "integrity": "sha512-YBvExkQYF7w0PxyeFLRyr817YVDhGxaCi5/uRRMqa4aWD3IFKRd+uNbpW1VWMdqQy8PZ7CElc+accXJcauPKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.3.0",
+        "luxon": "~3.3.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8231,6 +8277,15 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/macos-release": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/jwt": "^10.0.3",
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/schedule": "^3.0.4",
     "@nestjs/swagger": "^6.3.0",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^9.0.1",

--- a/src/api/library/chapter-log.service.spec.ts
+++ b/src/api/library/chapter-log.service.spec.ts
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Logger } from '@nestjs/common';
+import {
+  BACKFILL_CAP,
+  ChapterLogService,
+  DEDUP_WINDOW_MINUTES,
+} from './chapter-log.service';
+import { UserMangaChapterLog } from './user-manga-chapter-log.entity';
+import { Manga } from '@/api/mangas/manga.entity';
+
+/** Query builder chainable pour le lookup de dédup. */
+const createQb = (getOneResult: UserMangaChapterLog | null = null) => {
+  const qb: Record<string, jest.Mock> = {};
+  for (const method of ['where', 'andWhere', 'orderBy']) {
+    qb[method] = jest.fn().mockReturnValue(qb);
+  }
+  qb.getOne = jest.fn().mockResolvedValue(getOneResult);
+  return qb;
+};
+
+const existingLog = (chapterNumber: number): UserMangaChapterLog =>
+  ({
+    id: 5,
+    chapterNumber,
+    isSkipped: false,
+    isBonus: false,
+    scrollPosition: null,
+    readAt: new Date(),
+  } as UserMangaChapterLog);
+
+describe('ChapterLogService', () => {
+  let service: ChapterLogService;
+  let logRepo: {
+    save: jest.Mock;
+    insert: jest.Mock;
+    find: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let mangaRepo: { findOneBy: jest.Mock };
+
+  beforeEach(async () => {
+    logRepo = {
+      save: jest.fn(),
+      insert: jest.fn().mockResolvedValue({}),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(createQb(null)),
+    };
+    mangaRepo = {
+      findOneBy: jest.fn().mockResolvedValue({ mu_id: '42', title: 'T' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChapterLogService,
+        { provide: getRepositoryToken(UserMangaChapterLog), useValue: logRepo },
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+      ],
+    }).compile();
+
+    service = module.get<ChapterLogService>(ChapterLogService);
+  });
+
+  describe('recordChapterRead — fenêtre de dédup (B-5)', () => {
+    it('should reuse the existing row when the same read was logged less than 10 minutes ago', async () => {
+      const qb = createQb(existingLog(42));
+      logRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const dto = await service.recordChapterRead(1, 42, {
+        chapterNumber: 42,
+      });
+
+      expect(dto.id).toBe(5);
+      expect(logRepo.save).not.toHaveBeenCalled();
+      // Le filtre temporel est bien borné à now - DEDUP_WINDOW_MINUTES.
+      const readAtCall = qb.andWhere.mock.calls.find(
+        (call) => call[0] === 'log.readAt >= :windowStart',
+      );
+      expect(readAtCall).toBeDefined();
+      const windowStart: Date = readAtCall[1].windowStart;
+      const expectedMs = Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000;
+      expect(Math.abs(windowStart.getTime() - expectedMs)).toBeLessThan(5000);
+    });
+
+    it('should insert a new row when the last read of this chapter is older than the window', async () => {
+      // Une ligne plus vieille que la fenêtre n'est pas retournée par la
+      // requête filtrée (readAt >= now - 10 min) → getOne = null → replay.
+      logRepo.createQueryBuilder.mockReturnValue(createQb(null));
+      logRepo.save.mockImplementation(async (log: UserMangaChapterLog) => ({
+        ...log,
+        id: 9,
+        readAt: new Date(),
+      }));
+
+      const dto = await service.recordChapterRead(1, 42, {
+        chapterNumber: 42,
+      });
+
+      expect(logRepo.save).toHaveBeenCalledTimes(1);
+      expect(dto.id).toBe(9);
+      expect(dto.chapterNumber).toBe(42);
+    });
+  });
+
+  describe('recordBackfill (Chantier B)', () => {
+    it('should insert chapters oldRead+1..newRead in a single multi-row insert', async () => {
+      const inserted = await service.recordBackfill(1, 42, 90, 95);
+
+      expect(inserted).toBe(5);
+      expect(logRepo.insert).toHaveBeenCalledTimes(1);
+      const rows: UserMangaChapterLog[] = logRepo.insert.mock.calls[0][0];
+      expect(rows).toHaveLength(5);
+      expect(rows.map((r) => r.chapterNumber)).toEqual([91, 92, 93, 94, 95]);
+      for (const row of rows) {
+        expect(row.isSkipped).toBe(false);
+        expect(row.isBonus).toBe(false);
+        expect(row.scrollPosition).toBeNull();
+        expect(row.manga.mu_id).toBe('42');
+        expect(row.user.id).toBe(1);
+      }
+    });
+
+    it('should cap at BACKFILL_CAP rows and only log the LAST chapters (delta 1200 → 500 derniers)', async () => {
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+
+      const inserted = await service.recordBackfill(1, 42, 0, 1200);
+
+      expect(inserted).toBe(BACKFILL_CAP);
+      // Chunks de 100 → 5 INSERT pour 500 lignes.
+      expect(logRepo.insert).toHaveBeenCalledTimes(5);
+      const allRows: UserMangaChapterLog[] = logRepo.insert.mock.calls.flatMap(
+        (call) => call[0],
+      );
+      expect(allRows).toHaveLength(BACKFILL_CAP);
+      expect(allRows[0].chapterNumber).toBe(701);
+      expect(allRows[allRows.length - 1].chapterNumber).toBe(1200);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should skip the terminal chapter when the reader just logged it (dédup B-5)', async () => {
+      logRepo.createQueryBuilder.mockReturnValue(createQb(existingLog(95)));
+
+      const inserted = await service.recordBackfill(1, 42, 90, 95);
+
+      expect(inserted).toBe(4);
+      const rows: UserMangaChapterLog[] = logRepo.insert.mock.calls[0][0];
+      expect(rows.map((r) => r.chapterNumber)).toEqual([91, 92, 93, 94]);
+    });
+
+    it('should be a no-op on a decrement or equal pointer (B-4)', async () => {
+      expect(await service.recordBackfill(1, 42, 95, 90)).toBe(0);
+      expect(await service.recordBackfill(1, 42, 95, 95)).toBe(0);
+      expect(logRepo.insert).not.toHaveBeenCalled();
+      expect(logRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should use the transactional EntityManager repository when provided', async () => {
+      const managerRepo = {
+        insert: jest.fn().mockResolvedValue({}),
+        createQueryBuilder: jest.fn().mockReturnValue(createQb(null)),
+      };
+      const manager = {
+        getRepository: jest.fn().mockReturnValue(managerRepo),
+      };
+
+      const inserted = await service.recordBackfill(
+        1,
+        42,
+        90,
+        95,
+        manager as never,
+      );
+
+      expect(inserted).toBe(5);
+      expect(manager.getRepository).toHaveBeenCalledWith(UserMangaChapterLog);
+      expect(managerRepo.insert).toHaveBeenCalledTimes(1);
+      expect(logRepo.insert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/library/chapter-log.service.spec.ts
+++ b/src/api/library/chapter-log.service.spec.ts
@@ -62,16 +62,28 @@ describe('ChapterLogService', () => {
   });
 
   describe('recordChapterRead — fenêtre de dédup (B-5)', () => {
-    it('should reuse the existing row when the same read was logged less than 10 minutes ago', async () => {
+    it('should reuse the existing row (no new insert) but REFRESH scroll/bonus when logged less than 10 minutes ago', async () => {
       const qb = createQb(existingLog(42));
       logRepo.createQueryBuilder.mockReturnValue(qb);
+      logRepo.save.mockImplementation(async (log: UserMangaChapterLog) => log);
 
       const dto = await service.recordChapterRead(1, 42, {
         chapterNumber: 42,
+        scrollPosition: 5000,
+        isBonus: true,
       });
 
+      // Dédup : on réutilise la MÊME ligne (id 5), pas de nouvelle ligne.
       expect(dto.id).toBe(5);
-      expect(logRepo.save).not.toHaveBeenCalled();
+      // ...mais on persiste les données fraîches (scroll + bonus) au lieu
+      // de renvoyer la ligne inchangée.
+      expect(logRepo.save).toHaveBeenCalledTimes(1);
+      const saved: UserMangaChapterLog = logRepo.save.mock.calls[0][0];
+      expect(saved.id).toBe(5);
+      expect(saved.scrollPosition).toBe(5000);
+      expect(saved.isBonus).toBe(true);
+      expect(dto.scrollPosition).toBe(5000);
+      expect(dto.isBonus).toBe(true);
       // Le filtre temporel est bien borné à now - DEDUP_WINDOW_MINUTES.
       const readAtCall = qb.andWhere.mock.calls.find(
         (call) => call[0] === 'log.readAt >= :windowStart',
@@ -80,6 +92,25 @@ describe('ChapterLogService', () => {
       const windowStart: Date = readAtCall[1].windowStart;
       const expectedMs = Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000;
       expect(Math.abs(windowStart.getTime() - expectedMs)).toBeLessThan(5000);
+    });
+
+    it('should NOT overwrite scroll/bonus when the body omits them (undefined = préserve)', async () => {
+      const existing = existingLog(42);
+      existing.scrollPosition = 1234;
+      existing.isBonus = true;
+      logRepo.createQueryBuilder.mockReturnValue(createQb(existing));
+      logRepo.save.mockImplementation(async (log: UserMangaChapterLog) => log);
+
+      const dto = await service.recordChapterRead(1, 42, {
+        chapterNumber: 42,
+      });
+
+      // Body sans scrollPosition/isBonus → les valeurs existantes restent.
+      const saved: UserMangaChapterLog = logRepo.save.mock.calls[0][0];
+      expect(saved.scrollPosition).toBe(1234);
+      expect(saved.isBonus).toBe(true);
+      expect(dto.scrollPosition).toBe(1234);
+      expect(dto.isBonus).toBe(true);
     });
 
     it('should insert a new row when the last read of this chapter is older than the window', async () => {

--- a/src/api/library/chapter-log.service.ts
+++ b/src/api/library/chapter-log.service.ts
@@ -61,11 +61,19 @@ export class ChapterLogService {
     // B-5 : fenêtre d'idempotence — si la même lecture (user, manga,
     // chapitre, non-skippée) a déjà été journalisée il y a moins de
     // DEDUP_WINDOW_MINUTES (double-écriture reader + backfill updateChapter),
-    // on réutilise la ligne existante. Les replays plus vieux que la
-    // fenêtre restent journalisés normalement.
+    // on RÉUTILISE la ligne existante (pas de NOUVELLE ligne). Les replays
+    // plus vieux que la fenêtre restent journalisés normalement.
     const recent = await this.findRecentRead(userId, muId, body.chapterNumber);
     if (recent) {
-      return ChapterLogEntryDto.fromEntity(recent);
+      // ...mais on garde les données FRAÎCHES : sans ça, un scrollPosition
+      // qui avance et le passage isBonus=true seraient avalés pendant toute
+      // la fenêtre (reprise de lecture au mauvais endroit, chapitre jamais
+      // marqué terminé). On met à jour la ligne au lieu de la renvoyer telle
+      // quelle. Un body sans le champ (undefined) ne l'écrase pas.
+      recent.scrollPosition = body.scrollPosition ?? recent.scrollPosition;
+      recent.isBonus = body.isBonus ?? recent.isBonus;
+      const refreshed = await this.logRepo.save(recent);
+      return ChapterLogEntryDto.fromEntity(refreshed);
     }
 
     const log = new UserMangaChapterLog();

--- a/src/api/library/chapter-log.service.ts
+++ b/src/api/library/chapter-log.service.ts
@@ -1,10 +1,27 @@
 import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { UserMangaChapterLog } from './user-manga-chapter-log.entity';
 import { Manga } from '@/api/mangas/manga.entity';
 import User from '@/api/user/user.entity';
 import { ChapterLogEntryDto, RecordChapterLogDto } from './dto/chapter-log.dto';
+
+/**
+ * Cap de lignes journalisées par backfill (B-3) : au-delà, seuls les
+ * BACKFILL_CAP derniers chapitres sont loggés (le chiffre principal vient
+ * du pointeur `user_read_chapters` → rien de perdu sur la progression).
+ */
+export const BACKFILL_CAP = 500;
+
+/**
+ * Fenêtre d'idempotence du log (B-5), en minutes : une ligne de lecture
+ * (user, manga, chapitre, non-skippée) plus récente que cette fenêtre
+ * n'est pas dupliquée (double-écriture reader + updateChapter).
+ */
+export const DEDUP_WINDOW_MINUTES = 10;
+
+/** Taille de chunk pour les INSERT multi-rows du backfill. */
+const BACKFILL_INSERT_CHUNK_SIZE = 100;
 
 /**
  * Service du log additif de chapitres (Phase 5).
@@ -39,6 +56,16 @@ export class ChapterLogService {
     const manga = await this.mangaRepo.findOneBy({ mu_id: muId.toString() });
     if (!manga) {
       throw new NotFoundException(`Manga with mu_id ${muId} not found`);
+    }
+
+    // B-5 : fenêtre d'idempotence — si la même lecture (user, manga,
+    // chapitre, non-skippée) a déjà été journalisée il y a moins de
+    // DEDUP_WINDOW_MINUTES (double-écriture reader + backfill updateChapter),
+    // on réutilise la ligne existante. Les replays plus vieux que la
+    // fenêtre restent journalisés normalement.
+    const recent = await this.findRecentRead(userId, muId, body.chapterNumber);
+    if (recent) {
+      return ChapterLogEntryDto.fromEntity(recent);
     }
 
     const log = new UserMangaChapterLog();
@@ -108,5 +135,94 @@ export class ChapterLogService {
     existing.isSkipped = skipped;
     const saved = await this.logRepo.save(existing);
     return ChapterLogEntryDto.fromEntity(saved);
+  }
+
+  /**
+   * Backfill du journal pour le chemin manuel (Chantier B — B-2) : quand le
+   * pointeur `user_read_chapters` avance de `fromExclusive` à `toInclusive`,
+   * journalise les chapitres `from+1..to` en UN INSERT multi-rows (chunks
+   * de {@link BACKFILL_INSERT_CHUNK_SIZE}), `isBonus=false` (B-6),
+   * `isSkipped=false`, `scrollPosition=null`.
+   *
+   * - Cap B-3 : si le delta dépasse {@link BACKFILL_CAP}, seuls les
+   *   BACKFILL_CAP DERNIERS chapitres sont journalisés (+ warn).
+   * - Dédup B-5 (chapitre terminal uniquement) : si le reader vient de
+   *   journaliser le chapitre `to` il y a moins de
+   *   {@link DEDUP_WINDOW_MINUTES} minutes, il est exclu du backfill.
+   *
+   * @param manager EntityManager transactionnel optionnel (transaction du
+   *   pointeur dans `LibraryService.updateChapter`).
+   * @returns Nombre de lignes insérées.
+   */
+  async recordBackfill(
+    userId: number,
+    muId: number,
+    fromExclusive: number,
+    toInclusive: number,
+    manager?: EntityManager,
+  ): Promise<number> {
+    const end = Math.floor(toInclusive);
+    let start = Math.floor(fromExclusive) + 1;
+    if (end < start) return 0;
+
+    const delta = end - start + 1;
+    if (delta > BACKFILL_CAP) {
+      this.logger.warn(
+        `Backfill capped at ${BACKFILL_CAP} rows for user ${userId} manga ${muId} (delta=${delta}) — only chapters ${
+          end - BACKFILL_CAP + 1
+        }..${end} are logged`,
+      );
+      start = end - BACKFILL_CAP + 1;
+    }
+
+    const repo = manager
+      ? manager.getRepository(UserMangaChapterLog)
+      : this.logRepo;
+
+    // B-5 : le chapitre terminal a pu être journalisé par le reader juste
+    // avant le PUT /library/chapter — on ne le double pas.
+    const recentTerminal = await this.findRecentRead(userId, muId, end, repo);
+
+    const rows: UserMangaChapterLog[] = [];
+    for (let chapter = start; chapter <= end; chapter++) {
+      if (recentTerminal !== null && chapter === end) continue;
+      const log = new UserMangaChapterLog();
+      log.user = { id: userId } as User;
+      log.manga = { mu_id: muId.toString() } as Manga;
+      log.chapterNumber = chapter;
+      log.isBonus = false;
+      log.isSkipped = false;
+      log.scrollPosition = null;
+      rows.push(log);
+    }
+    if (rows.length === 0) return 0;
+
+    for (let i = 0; i < rows.length; i += BACKFILL_INSERT_CHUNK_SIZE) {
+      await repo.insert(rows.slice(i, i + BACKFILL_INSERT_CHUNK_SIZE));
+    }
+    return rows.length;
+  }
+
+  /**
+   * Cherche une ligne de lecture (non-skippée) pour (user, manga, chapitre)
+   * plus récente que la fenêtre d'idempotence {@link DEDUP_WINDOW_MINUTES}.
+   * L'index (user_id, manga_id, chapterNumber) couvre le lookup.
+   */
+  private async findRecentRead(
+    userId: number,
+    muId: number,
+    chapterNumber: number,
+    repo: Repository<UserMangaChapterLog> = this.logRepo,
+  ): Promise<UserMangaChapterLog | null> {
+    const windowStart = new Date(Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000);
+    return repo
+      .createQueryBuilder('log')
+      .where('log.user_id = :userId', { userId })
+      .andWhere('log.manga_id = :mangaId', { mangaId: muId.toString() })
+      .andWhere('log.chapterNumber = :chapterNumber', { chapterNumber })
+      .andWhere('log.isSkipped = :skipped', { skipped: false })
+      .andWhere('log.readAt >= :windowStart', { windowStart })
+      .orderBy('log.readAt', 'DESC')
+      .getOne();
   }
 }

--- a/src/api/library/chapter-report.controller.ts
+++ b/src/api/library/chapter-report.controller.ts
@@ -12,7 +12,6 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '@/api/user/auth/guard/auth.guard';
 import { UserDecorator } from '@/shared/Decorator/user.decorator';
 import { ChapterReportService } from './chapter-report.service';
@@ -20,6 +19,7 @@ import {
   ReportChaptersDto,
   ReportChaptersResultDto,
 } from './dto/report-chapters.dto';
+import { UserThrottlerGuard } from './user-throttler.guard';
 
 /**
  * Sous-controller du module Library dédié au signalement « plus de
@@ -55,10 +55,16 @@ export class ChapterReportController {
     status: 404,
     description: "Manga inconnu ou absent de la bibliothèque de l'utilisateur",
   })
-  @ApiResponse({ status: 429, description: 'Trop de signalements (10/heure)' })
-  @Throttle({ default: { ttl: 3_600_000, limit: 10 } })
+  @ApiResponse({
+    status: 429,
+    description: 'Trop de signalements (10/heure et par utilisateur)',
+  })
+  // Rate-limit strict 10/h PAR UTILISATEUR (et non par IP) : cf.
+  // `UserThrottlerGuard`. Le tracking par IP serait un budget global partagé
+  // derrière le reverse proxy NPMplus. Le garde DOIT suivre `JwtAuthGuard`
+  // (ordre des gardes de route) pour disposer de `req.user`.
   @Post(':muId/report-chapters')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, UserThrottlerGuard)
   async reportChapters(
     @Param('muId', ParseIntPipe) muId: number,
     @Body() body: ReportChaptersDto,

--- a/src/api/library/chapter-report.controller.ts
+++ b/src/api/library/chapter-report.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Body,
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { JwtAuthGuard } from '@/api/user/auth/guard/auth.guard';
+import { UserDecorator } from '@/shared/Decorator/user.decorator';
+import { ChapterReportService } from './chapter-report.service';
+import {
+  ReportChaptersDto,
+  ReportChaptersResultDto,
+} from './dto/report-chapters.dto';
+
+/**
+ * Sous-controller du module Library dédié au signalement « plus de
+ * chapitres » (Chantier A). Séparé de `LibraryController` qui dépasse déjà
+ * la limite de 200 lignes (règle : les fichiers au-dessus du seuil ne
+ * doivent pas grossir — découpage en sous-controllers par domaine).
+ */
+@ApiTags('Library')
+@ApiBearerAuth()
+@Controller('library')
+export class ChapterReportController {
+  constructor(private readonly chapterReportService: ChapterReportService) {}
+
+  @ApiOperation({
+    summary:
+      'Signaler que le manga a plus de chapitres que le total officiel connu',
+    description:
+      "Le report devient l'override personnel de l'user : son total effectif = max(total officiel, total signalé). " +
+      'Quand au moins 2 users distincts signalent un total concordant, le total officiel est consolidé (bump au MIN des totaux signalés). ' +
+      'Le manga doit être dans la bibliothèque (gate anti-abus), le total signalé strictement supérieur au total officiel et borné à total + 200.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Report enregistré',
+    type: ReportChaptersResultDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Total signalé ≤ total officiel, ou > total officiel + 200 (garde-fou anti-typo)',
+  })
+  @ApiResponse({
+    status: 404,
+    description: "Manga inconnu ou absent de la bibliothèque de l'utilisateur",
+  })
+  @ApiResponse({ status: 429, description: 'Trop de signalements (10/heure)' })
+  @Throttle({ default: { ttl: 3_600_000, limit: 10 } })
+  @Post(':muId/report-chapters')
+  @UseGuards(JwtAuthGuard)
+  async reportChapters(
+    @Param('muId', ParseIntPipe) muId: number,
+    @Body() body: ReportChaptersDto,
+    @UserDecorator() user: any,
+  ): Promise<ReportChaptersResultDto> {
+    return this.chapterReportService.reportMoreChapters(
+      user.id,
+      muId,
+      body.reportedTotal,
+    );
+  }
+}

--- a/src/api/library/chapter-report.service.spec.ts
+++ b/src/api/library/chapter-report.service.spec.ts
@@ -1,0 +1,276 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  ChapterReportService,
+  MAX_REPORT_DELTA,
+  MIN_REPORTERS,
+} from './chapter-report.service';
+import { MangaChapterReport } from './manga-chapter-report.entity';
+import { Manga } from '@/api/mangas/manga.entity';
+import { UserManga } from '@/api/mangas/user-manga.entity';
+
+/** Query builder chainable générique — chaque appel retourne le même mock. */
+const createQb = () => {
+  const qb: Record<string, jest.Mock> = {};
+  const chainMethods = [
+    'select',
+    'addSelect',
+    'where',
+    'andWhere',
+    'insert',
+    'into',
+    'values',
+    'orUpdate',
+    'update',
+    'set',
+    'setParameter',
+    'delete',
+    'from',
+    'orderBy',
+  ];
+  for (const method of chainMethods) {
+    qb[method] = jest.fn().mockReturnValue(qb);
+  }
+  qb.execute = jest.fn().mockResolvedValue({});
+  qb.getRawOne = jest.fn().mockResolvedValue(undefined);
+  qb.getRawMany = jest.fn().mockResolvedValue([]);
+  return qb;
+};
+
+describe('ChapterReportService', () => {
+  let service: ChapterReportService;
+  let reportRepo: {
+    findOne: jest.Mock;
+    delete: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let mangaRepo: { findOneBy: jest.Mock; createQueryBuilder: jest.Mock };
+  let userMangaRepo: { findOne: jest.Mock };
+
+  const mangaWithTotal = (total: number) => ({
+    mu_id: '42',
+    total_chapters: total,
+    completed: false,
+  });
+
+  beforeEach(async () => {
+    reportRepo = {
+      findOne: jest.fn(),
+      delete: jest.fn().mockResolvedValue({}),
+      createQueryBuilder: jest.fn(),
+    };
+    mangaRepo = { findOneBy: jest.fn(), createQueryBuilder: jest.fn() };
+    userMangaRepo = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChapterReportService,
+        {
+          provide: getRepositoryToken(MangaChapterReport),
+          useValue: reportRepo,
+        },
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+        { provide: getRepositoryToken(UserManga), useValue: userMangaRepo },
+      ],
+    }).compile();
+
+    service = module.get<ChapterReportService>(ChapterReportService);
+  });
+
+  describe('reportMoreChapters — validations', () => {
+    it('should throw 404 when the manga is not in the user library (anti-abuse gate)', async () => {
+      userMangaRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.reportMoreChapters(1, 42, 95)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw 400 when reportedTotal is not above the known total', async () => {
+      userMangaRepo.findOne.mockResolvedValue({ id: 10 });
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+
+      await expect(service.reportMoreChapters(1, 42, 90)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw 400 when reportedTotal exceeds total + MAX_REPORT_DELTA', async () => {
+      userMangaRepo.findOne.mockResolvedValue({ id: 10 });
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+
+      await expect(
+        service.reportMoreChapters(1, 42, 90 + MAX_REPORT_DELTA + 1),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('reportMoreChapters — upsert', () => {
+    let qb: Record<string, jest.Mock>;
+
+    beforeEach(() => {
+      userMangaRepo.findOne.mockResolvedValue({ id: 10 });
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+      qb = createQb();
+      reportRepo.createQueryBuilder.mockReturnValue(qb);
+      jest.spyOn(service, 'consolidate').mockResolvedValue(false);
+    });
+
+    it('should upsert on (user_id, manga_id) so a second report from the same user overwrites', async () => {
+      await service.reportMoreChapters(1, 42, 95);
+      await service.reportMoreChapters(1, 42, 97);
+
+      expect(qb.orUpdate).toHaveBeenCalledTimes(2);
+      expect(qb.orUpdate).toHaveBeenCalledWith(
+        ['reported_total', 'updated_at'],
+        ['user_id', 'manga_id'],
+      );
+      expect(qb.values.mock.calls[0][0].reported_total).toBe(95);
+      expect(qb.values.mock.calls[1][0].reported_total).toBe(97);
+    });
+
+    it('should return the effective total (max of official and reported)', async () => {
+      const result = await service.reportMoreChapters(1, 42, 95);
+
+      expect(result).toEqual({
+        reportedTotal: 95,
+        effectiveTotalChapters: 95,
+        consolidated: false,
+      });
+    });
+
+    it('should re-read the official total after a consolidation', async () => {
+      (service.consolidate as jest.Mock).mockResolvedValue(true);
+      mangaRepo.findOneBy
+        .mockResolvedValueOnce(mangaWithTotal(90))
+        .mockResolvedValueOnce(mangaWithTotal(95));
+
+      const result = await service.reportMoreChapters(1, 42, 95);
+
+      expect(result).toEqual({
+        reportedTotal: 95,
+        effectiveTotalChapters: 95,
+        consolidated: true,
+      });
+    });
+  });
+
+  describe('consolidate', () => {
+    it('should do nothing with a single reporter (< MIN_REPORTERS)', async () => {
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+      const selectQb = createQb();
+      selectQb.getRawOne.mockResolvedValue({
+        reporters: '1',
+        min_reported: '95',
+      });
+      reportRepo.createQueryBuilder.mockReturnValue(selectQb);
+
+      const consolidated = await service.consolidate(42);
+
+      expect(MIN_REPORTERS).toBe(2);
+      expect(consolidated).toBe(false);
+      expect(mangaRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should bump the official total to the MIN of concordant reports (2 users, 95/97)', async () => {
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+      const selectQb = createQb();
+      selectQb.getRawOne.mockResolvedValue({
+        reporters: '2',
+        min_reported: '95',
+      });
+      const deleteQb = createQb();
+      reportRepo.createQueryBuilder
+        .mockReturnValueOnce(selectQb)
+        .mockReturnValueOnce(deleteQb);
+      const updateQb = createQb();
+      mangaRepo.createQueryBuilder.mockReturnValue(updateQb);
+
+      const consolidated = await service.consolidate(42);
+
+      expect(consolidated).toBe(true);
+      // newTotal = max(90 existant, 95 = MIN des reports concordants) = 95,
+      // écrit en GREATEST (monotone croissant, pas de régression).
+      expect(updateQb.setParameter).toHaveBeenCalledWith('newTotal', 95);
+      const setArg = updateQb.set.mock.calls[0][0];
+      expect(typeof setArg.total_chapters).toBe('function');
+      expect(setArg.total_chapters()).toBe(
+        'GREATEST(total_chapters, :newTotal)',
+      );
+      // completed n'est PAS touché par la consolidation.
+      expect(setArg.completed).toBeUndefined();
+    });
+
+    it('should purge the reports covered by the new total (≤ newTotal)', async () => {
+      mangaRepo.findOneBy.mockResolvedValue(mangaWithTotal(90));
+      const selectQb = createQb();
+      selectQb.getRawOne.mockResolvedValue({
+        reporters: '2',
+        min_reported: '95',
+      });
+      const deleteQb = createQb();
+      reportRepo.createQueryBuilder
+        .mockReturnValueOnce(selectQb)
+        .mockReturnValueOnce(deleteQb);
+      mangaRepo.createQueryBuilder.mockReturnValue(createQb());
+
+      await service.consolidate(42);
+
+      expect(deleteQb.delete).toHaveBeenCalled();
+      expect(deleteQb.andWhere).toHaveBeenCalledWith(
+        'reported_total <= :newTotal',
+        { newTotal: 95 },
+      );
+      expect(deleteQb.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('getEffectiveTotal', () => {
+    it('should return the official total when the user has no report', async () => {
+      reportRepo.findOne.mockResolvedValue(null);
+
+      expect(await service.getEffectiveTotal(1, 42, 90)).toBe(90);
+      expect(reportRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('should return the reported total when it is still above the official one', async () => {
+      reportRepo.findOne.mockResolvedValue({ id: 7, reported_total: 95 });
+
+      expect(await service.getEffectiveTotal(1, 42, 90)).toBe(95);
+      expect(reportRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('should lazily purge the report once the official total caught up', async () => {
+      reportRepo.findOne.mockResolvedValue({ id: 7, reported_total: 95 });
+
+      expect(await service.getEffectiveTotal(1, 42, 100)).toBe(100);
+      expect(reportRepo.delete).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('getUserReportsByMangaIds', () => {
+    it('should return an empty map without querying for an empty id list', async () => {
+      const result = await service.getUserReportsByMangaIds(1, []);
+
+      expect(result.size).toBe(0);
+      expect(reportRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should map mu_id → reported_total in a single IN query', async () => {
+      const qb = createQb();
+      qb.getRawMany.mockResolvedValue([
+        { manga_id: '42', reported_total: '95' },
+        { manga_id: '77', reported_total: '120' },
+      ]);
+      reportRepo.createQueryBuilder.mockReturnValue(qb);
+
+      const result = await service.getUserReportsByMangaIds(1, [42, 77, 99]);
+
+      expect(reportRepo.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(result.get('42')).toBe(95);
+      expect(result.get('77')).toBe(120);
+      expect(result.has('99')).toBe(false);
+    });
+  });
+});

--- a/src/api/library/chapter-report.service.ts
+++ b/src/api/library/chapter-report.service.ts
@@ -1,0 +1,228 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import User from '@/api/user/user.entity';
+import { Manga } from '@/api/mangas/manga.entity';
+import { UserManga } from '@/api/mangas/user-manga.entity';
+import { MangaChapterReport } from './manga-chapter-report.entity';
+import { ReportChaptersResultDto } from './dto/report-chapters.dto';
+
+/**
+ * Nombre minimum de rapporteurs distincts concordants pour consolider le
+ * total officiel (`manga.total_chapters`).
+ */
+export const MIN_REPORTERS = 2;
+
+/**
+ * Delta maximum accepté entre le total officiel et un total signalé —
+ * garde-fou anti-typo / anti-abus (collusion bornée).
+ */
+export const MAX_REPORT_DELTA = 200;
+
+/**
+ * Service dédié du signalement « plus de chapitres » (Chantier A).
+ *
+ * Séparé de `LibraryService` (déjà ~350 lignes) : gère le cycle de vie des
+ * `manga_chapter_report` — upsert par user, calcul du total effectif,
+ * purge lazy quand le total officiel rattrape, consolidation communautaire.
+ */
+@Injectable()
+export class ChapterReportService {
+  private readonly logger = new Logger(ChapterReportService.name);
+
+  constructor(
+    @InjectRepository(MangaChapterReport)
+    private readonly reportRepository: Repository<MangaChapterReport>,
+    @InjectRepository(Manga)
+    private readonly mangaRepository: Repository<Manga>,
+    @InjectRepository(UserManga)
+    private readonly userMangaRepository: Repository<UserManga>,
+  ) {}
+
+  /**
+   * Enregistre (upsert) le signalement d'un user, puis tente la
+   * consolidation communautaire.
+   *
+   * Gate anti-abus : le manga doit être dans la bibliothèque de l'user
+   * (404 sinon). Le total signalé doit être strictement supérieur au total
+   * officiel (400) et borné à `total + MAX_REPORT_DELTA` (400).
+   */
+  async reportMoreChapters(
+    userId: number,
+    muId: number,
+    reportedTotal: number,
+  ): Promise<ReportChaptersResultDto> {
+    const userManga = await this.userMangaRepository.findOne({
+      where: { user: { id: userId }, manga: { mu_id: muId.toString() } },
+    });
+    if (!userManga) {
+      throw new NotFoundException(
+        `Nothing found in user's library for userId: ${userId} and muId: ${muId} — the manga must be in the library to report chapters`,
+      );
+    }
+
+    const manga = await this.mangaRepository.findOneBy({
+      mu_id: muId.toString(),
+    });
+    if (!manga) {
+      throw new NotFoundException(`Manga with mu_id ${muId} not found`);
+    }
+
+    if (reportedTotal <= manga.total_chapters) {
+      throw new BadRequestException(
+        `Reported total (${reportedTotal}) must be strictly greater than the known total (${manga.total_chapters})`,
+      );
+    }
+    if (reportedTotal > manga.total_chapters + MAX_REPORT_DELTA) {
+      throw new BadRequestException(
+        `Reported total (${reportedTotal}) exceeds the maximum accepted value (${
+          manga.total_chapters + MAX_REPORT_DELTA
+        } = known total + ${MAX_REPORT_DELTA})`,
+      );
+    }
+
+    // Upsert : un report actif par (user, manga) — le nouveau écrase l'ancien.
+    await this.reportRepository
+      .createQueryBuilder()
+      .insert()
+      .into(MangaChapterReport)
+      .values({
+        user: { id: userId } as User,
+        manga,
+        reported_total: reportedTotal,
+      })
+      .orUpdate(['reported_total', 'updated_at'], ['user_id', 'manga_id'])
+      .execute();
+
+    const consolidated = await this.consolidate(muId);
+
+    // Si consolidé, le total officiel a pu bouger — on relit pour renvoyer
+    // le total effectif exact au client.
+    const freshManga = consolidated
+      ? await this.mangaRepository.findOneBy({ mu_id: muId.toString() })
+      : manga;
+    const officialTotal = freshManga?.total_chapters ?? manga.total_chapters;
+
+    return {
+      reportedTotal,
+      effectiveTotalChapters: Math.max(officialTotal, reportedTotal),
+      consolidated,
+    };
+  }
+
+  /**
+   * Total effectif pour un user : `max(total officiel, report user)`.
+   *
+   * Purge lazy : si le total officiel a rattrapé (ou dépassé) le report,
+   * la ligne ne sert plus à rien → DELETE et retour du total officiel.
+   */
+  async getEffectiveTotal(
+    userId: number,
+    muId: number,
+    mangaTotal: number,
+  ): Promise<number> {
+    const report = await this.reportRepository.findOne({
+      where: { user: { id: userId }, manga: { mu_id: muId.toString() } },
+    });
+    if (!report) return mangaTotal;
+
+    if (report.reported_total <= mangaTotal) {
+      await this.reportRepository.delete(report.id);
+      return mangaTotal;
+    }
+    return report.reported_total;
+  }
+
+  /**
+   * Reports actifs d'un user pour un lot de mangas — 1 seule requête IN
+   * (pas de N+1 pour `GET /library/all`).
+   *
+   * @returns Map `mu_id` (string) → reported_total.
+   */
+  async getUserReportsByMangaIds(
+    userId: number,
+    muIds: number[],
+  ): Promise<Map<string, number>> {
+    if (muIds.length === 0) return new Map();
+
+    const rows: Array<{ manga_id: string; reported_total: string }> =
+      await this.reportRepository
+        .createQueryBuilder('r')
+        .select('r.manga_id::text', 'manga_id')
+        .addSelect('r.reported_total', 'reported_total')
+        .where('r.user_id = :userId', { userId })
+        .andWhere('r.manga_id IN (:...ids)', {
+          ids: muIds.map((id) => id.toString()),
+        })
+        .getRawMany();
+
+    return new Map(
+      rows.map((r) => [String(r.manga_id), Number(r.reported_total)]),
+    );
+  }
+
+  /**
+   * Consolidation communautaire : si ≥ MIN_REPORTERS users distincts ont
+   * signalé un total > total officiel, on bumpe `manga.total_chapters` au
+   * MIN des totaux signalés concordants (conservateur), sans toucher
+   * `completed`, puis on purge les reports couverts (≤ nouveau total).
+   *
+   * Écriture GREATEST : monotone croissante — convergente face au refresh
+   * 6h de `checkManga` (pas de lock nécessaire).
+   *
+   * @returns true si une consolidation a eu lieu.
+   */
+  async consolidate(muId: number): Promise<boolean> {
+    const manga = await this.mangaRepository.findOneBy({
+      mu_id: muId.toString(),
+    });
+    if (!manga) return false;
+
+    const row: { reporters: string; min_reported: string } | undefined =
+      await this.reportRepository
+        .createQueryBuilder('r')
+        .select('COUNT(DISTINCT r.user_id)', 'reporters')
+        .addSelect('MIN(r.reported_total)', 'min_reported')
+        .where('r.manga_id = :muId', { muId: muId.toString() })
+        .andWhere('r.reported_total > :total', {
+          total: manga.total_chapters,
+        })
+        .getRawOne();
+
+    const reporters = Number(row?.reporters ?? 0);
+    if (reporters < MIN_REPORTERS) return false;
+
+    const newTotal = Math.max(
+      manga.total_chapters,
+      Number(row.min_reported) || 0,
+    );
+
+    await this.mangaRepository
+      .createQueryBuilder()
+      .update(Manga)
+      .set({
+        total_chapters: () => 'GREATEST(total_chapters, :newTotal)',
+      })
+      .setParameter('newTotal', newTotal)
+      .where('mu_id = :muId', { muId: muId.toString() })
+      .execute();
+
+    await this.reportRepository
+      .createQueryBuilder()
+      .delete()
+      .from(MangaChapterReport)
+      .where('manga_id = :muId', { muId: muId.toString() })
+      .andWhere('reported_total <= :newTotal', { newTotal })
+      .execute();
+
+    this.logger.log(
+      `Consolidated total_chapters to ${newTotal} for manga ${muId} (${reporters} concordant reporters)`,
+    );
+    return true;
+  }
+}

--- a/src/api/library/dto/report-chapters.dto.ts
+++ b/src/api/library/dto/report-chapters.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * Body de `POST /library/:muId/report-chapters` (Chantier A).
+ *
+ * Le total signalé doit être strictement supérieur au total officiel et
+ * borné à `total + MAX_REPORT_DELTA` (garde-fou anti-typo) — validé côté
+ * service (`ChapterReportService.reportMoreChapters`).
+ */
+export class ReportChaptersDto {
+  @ApiProperty({
+    description:
+      'Total de chapitres constaté par l’utilisateur (doit être > au total officiel connu, et ≤ total + 200)',
+    example: 120,
+  })
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  reportedTotal: number;
+}
+
+/**
+ * Réponse de `POST /library/:muId/report-chapters`.
+ */
+export class ReportChaptersResultDto {
+  @ApiProperty({ description: 'Total signalé enregistré', example: 120 })
+  reportedTotal: number;
+
+  @ApiProperty({
+    description:
+      'Total effectif pour cet utilisateur après le report : max(total officiel, total signalé)',
+    example: 120,
+  })
+  effectiveTotalChapters: number;
+
+  @ApiProperty({
+    description:
+      'true si le report a déclenché une consolidation communautaire (bump du total officiel)',
+    example: false,
+  })
+  consolidated: boolean;
+}

--- a/src/api/library/library.module.ts
+++ b/src/api/library/library.module.ts
@@ -14,6 +14,7 @@ import { ChapterLogService } from './chapter-log.service';
 import { MangaChapterReport } from './manga-chapter-report.entity';
 import { ChapterReportService } from './chapter-report.service';
 import { ChapterReportController } from './chapter-report.controller';
+import { UserThrottlerGuard } from './user-throttler.guard';
 import { RecoCacheModule } from '../recommendations/reco-cache.module';
 
 @Module({
@@ -39,6 +40,9 @@ import { RecoCacheModule } from '../recommendations/reco-cache.module';
     UpdateMangaService,
     ChapterLogService,
     ChapterReportService,
+    // Garde de rate-limit par utilisateur pour la route report-chapters
+    // (provider pour bénéficier de l'injection throttler + onModuleInit).
+    UserThrottlerGuard,
   ],
   exports: [LibraryService, ChapterLogService, ChapterReportService],
 })

--- a/src/api/library/library.module.ts
+++ b/src/api/library/library.module.ts
@@ -11,6 +11,9 @@ import { HttpModule } from '@nestjs/axios';
 import { UpdateMangaService } from '../mangas/update-manga.service';
 import { UserMangaChapterLog } from './user-manga-chapter-log.entity';
 import { ChapterLogService } from './chapter-log.service';
+import { MangaChapterReport } from './manga-chapter-report.entity';
+import { ChapterReportService } from './chapter-report.service';
+import { ChapterReportController } from './chapter-report.controller';
 import { RecoCacheModule } from '../recommendations/reco-cache.module';
 
 @Module({
@@ -21,15 +24,22 @@ import { RecoCacheModule } from '../recommendations/reco-cache.module';
     // sans dépendance → pas de cycle library → recommendations.
     RecoCacheModule,
     HttpModule,
-    TypeOrmModule.forFeature([Manga, User, UserManga, UserMangaChapterLog]),
+    TypeOrmModule.forFeature([
+      Manga,
+      User,
+      UserManga,
+      UserMangaChapterLog,
+      MangaChapterReport,
+    ]),
   ],
-  controllers: [LibraryController],
+  controllers: [LibraryController, ChapterReportController],
   providers: [
     UserService,
     LibraryService,
     UpdateMangaService,
     ChapterLogService,
+    ChapterReportService,
   ],
-  exports: [LibraryService, ChapterLogService],
+  exports: [LibraryService, ChapterLogService, ChapterReportService],
 })
 export class LibraryModule {}

--- a/src/api/library/library.service.spec.ts
+++ b/src/api/library/library.service.spec.ts
@@ -1,0 +1,394 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken, getRepositoryToken } from '@nestjs/typeorm';
+import { LibraryService } from './library.service';
+import { UserService } from '@/api/user/user.service';
+import { MangasService } from '@/api/mangas/mangas.service';
+import { UpdateMangaService } from '@/api/mangas/update-manga.service';
+import { RecoCacheService } from '@/api/recommendations/reco-cache.service';
+import { ChapterLogService } from './chapter-log.service';
+import { ChapterReportService } from './chapter-report.service';
+import { ChapterException } from './exceptions/chapter.exception';
+import { ReadingStatus } from './reading-status.enum';
+import User from '@/api/user/user.entity';
+import { Manga } from '@/api/mangas/manga.entity';
+import { UserManga } from '@/api/mangas/user-manga.entity';
+
+/** Query builder chainable générique. */
+const createQb = () => {
+  const qb: Record<string, jest.Mock> = {};
+  for (const method of ['update', 'set', 'setParameter', 'where', 'andWhere']) {
+    qb[method] = jest.fn().mockReturnValue(qb);
+  }
+  qb.execute = jest.fn().mockResolvedValue({});
+  return qb;
+};
+
+describe('LibraryService — updateChapter (chantiers A & B)', () => {
+  let service: LibraryService;
+  let userRepo: { findOne: jest.Mock };
+  let mangaRepo: { save: jest.Mock; createQueryBuilder: jest.Mock };
+  let userMangaRepo: { findOne: jest.Mock; createQueryBuilder: jest.Mock };
+  let mangasService: {
+    returnMangaIfExist: jest.Mock;
+    getMangaDetails: jest.Mock;
+  };
+  let updateMangaService: {
+    getMangasIds: jest.Mock;
+    checkIfMangaArrayInfoIsOutdated: jest.Mock;
+  };
+  let recoCache: { invalidateUser: jest.Mock };
+  let chapterLogService: { recordBackfill: jest.Mock };
+  let chapterReportService: {
+    getEffectiveTotal: jest.Mock;
+    getUserReportsByMangaIds: jest.Mock;
+  };
+  let dataSource: { transaction: jest.Mock };
+  let managerMock: { createQueryBuilder: jest.Mock; getRepository: jest.Mock };
+  let managerQb: Record<string, jest.Mock>;
+  let repoQb: Record<string, jest.Mock>;
+
+  /** Manga frais en BDD (updated_at récent → pas de refresh MU). */
+  const freshManga = (total: number, completed = false) => ({
+    mu_id: '42',
+    total_chapters: total,
+    completed,
+    updated_at: new Date(),
+  });
+
+  /** Entrée bibliothèque du user pour le manga 42. */
+  const libraryEntry = (oldRead: number, total = 100) => ({
+    manga: {
+      mu_id: '42',
+      title: 'Test Manga',
+      year: 2020,
+      medium_cover_url: 'cover.jpg',
+      rating: 7,
+      total_chapters: total,
+      completed: false,
+      associated: [],
+    },
+    user_read_chapters: oldRead,
+    readingStatus: ReadingStatus.Reading,
+    user_rating: 0,
+    custom_link: null,
+    lastUpdated: new Date(),
+  });
+
+  beforeEach(async () => {
+    userRepo = { findOne: jest.fn() };
+    mangaRepo = { save: jest.fn(), createQueryBuilder: jest.fn() };
+    repoQb = createQb();
+    userMangaRepo = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(repoQb),
+    };
+    mangasService = {
+      returnMangaIfExist: jest.fn(),
+      getMangaDetails: jest.fn(),
+    };
+    updateMangaService = {
+      getMangasIds: jest.fn().mockResolvedValue([42]),
+      checkIfMangaArrayInfoIsOutdated: jest.fn().mockResolvedValue([]),
+    };
+    recoCache = { invalidateUser: jest.fn() };
+    chapterLogService = { recordBackfill: jest.fn().mockResolvedValue(0) };
+    chapterReportService = {
+      getEffectiveTotal: jest.fn(),
+      getUserReportsByMangaIds: jest.fn().mockResolvedValue(new Map()),
+    };
+    managerQb = createQb();
+    managerMock = {
+      createQueryBuilder: jest.fn().mockReturnValue(managerQb),
+      getRepository: jest.fn(),
+    };
+    dataSource = {
+      transaction: jest.fn(async (cb) => cb(managerMock)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibraryService,
+        { provide: UserService, useValue: {} },
+        { provide: MangasService, useValue: mangasService },
+        { provide: UpdateMangaService, useValue: updateMangaService },
+        { provide: RecoCacheService, useValue: recoCache },
+        { provide: ChapterLogService, useValue: chapterLogService },
+        { provide: ChapterReportService, useValue: chapterReportService },
+        { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+        { provide: getRepositoryToken(UserManga), useValue: userMangaRepo },
+      ],
+    }).compile();
+
+    service = module.get<LibraryService>(LibraryService);
+  });
+
+  const givenUserWithEntry = (oldRead: number, total = 100) => {
+    userRepo.findOne.mockResolvedValue({
+      id: 1,
+      user_mangas: [libraryEntry(oldRead, total)],
+    });
+  };
+
+  it('should throw a 406 ChapterException above the EFFECTIVE total (official + report)', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(107);
+
+    await expect(service.updateChapter(1, 42, 108)).rejects.toThrow(
+      ChapterException,
+    );
+    expect(dataSource.transaction).not.toHaveBeenCalled();
+    expect(repoQb.execute).not.toHaveBeenCalled();
+  });
+
+  it('should accept a progression between the official total and the reported one', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(107);
+
+    await expect(service.updateChapter(1, 42, 105)).resolves.toBe(true);
+    // 105 < 107 (total effectif) → toujours en cours de lecture.
+    expect(managerQb.set.mock.calls[0][0].readingStatus).toBe(
+      ReadingStatus.Reading,
+    );
+    expect(managerQb.set.mock.calls[0][0].user_read_chapters).toBe(105);
+  });
+
+  it('should stay Reading while below the effective total, even above the official one', async () => {
+    givenUserWithEntry(100);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100, true));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(107);
+
+    await service.updateChapter(1, 42, 101);
+
+    expect(managerQb.set.mock.calls[0][0].readingStatus).toBe(
+      ReadingStatus.Reading,
+    );
+  });
+
+  it('should switch to CaughtUp at the effective total when the manga is not completed', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100, false));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(107);
+
+    await service.updateChapter(1, 42, 107);
+
+    expect(managerQb.set.mock.calls[0][0].readingStatus).toBe(
+      ReadingStatus.CaughtUp,
+    );
+  });
+
+  it('should switch to Completed at the effective total when the manga is completed', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100, true));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(107);
+
+    await service.updateChapter(1, 42, 107);
+
+    expect(managerQb.set.mock.calls[0][0].readingStatus).toBe(
+      ReadingStatus.Completed,
+    );
+  });
+
+  it('should backfill the chapter log from oldRead+1 to newRead inside the transaction', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(100);
+
+    await service.updateChapter(1, 42, 95);
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(chapterLogService.recordBackfill).toHaveBeenCalledTimes(1);
+    expect(chapterLogService.recordBackfill).toHaveBeenCalledWith(
+      1,
+      42,
+      90,
+      95,
+      managerMock,
+    );
+  });
+
+  it('should NOT write any chapter log on a decrement (additive journal, B-4)', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(100);
+
+    await expect(service.updateChapter(1, 42, 80)).resolves.toBe(true);
+
+    expect(chapterLogService.recordBackfill).not.toHaveBeenCalled();
+    expect(dataSource.transaction).not.toHaveBeenCalled();
+    // Le pointeur est quand même mis à jour (hors transaction).
+    expect(repoQb.set.mock.calls[0][0].user_read_chapters).toBe(80);
+    expect(repoQb.execute).toHaveBeenCalled();
+  });
+
+  it('should fall back to sequential writes when the transaction fails (pointer first)', async () => {
+    givenUserWithEntry(90);
+    mangasService.returnMangaIfExist.mockResolvedValue(freshManga(100));
+    chapterReportService.getEffectiveTotal.mockResolvedValue(100);
+    dataSource.transaction.mockRejectedValue(new Error('tx unavailable'));
+
+    await expect(service.updateChapter(1, 42, 95)).resolves.toBe(true);
+
+    // Fallback : UPDATE du pointeur via le repository (hors transaction)…
+    expect(repoQb.set.mock.calls[0][0].user_read_chapters).toBe(95);
+    expect(repoQb.execute).toHaveBeenCalled();
+    // …puis backfill best-effort SANS manager.
+    expect(chapterLogService.recordBackfill).toHaveBeenCalledWith(
+      1,
+      42,
+      90,
+      95,
+    );
+  });
+});
+
+describe('LibraryService — checkManga (A-5 GREATEST)', () => {
+  let service: LibraryService;
+  let mangaRepo: { save: jest.Mock; createQueryBuilder: jest.Mock };
+  let mangasService: {
+    returnMangaIfExist: jest.Mock;
+    getMangaDetails: jest.Mock;
+  };
+  let updateQb: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    updateQb = createQb();
+    mangaRepo = {
+      save: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(updateQb),
+    };
+    mangasService = {
+      returnMangaIfExist: jest.fn(),
+      getMangaDetails: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibraryService,
+        { provide: UserService, useValue: {} },
+        { provide: MangasService, useValue: mangasService },
+        { provide: UpdateMangaService, useValue: {} },
+        { provide: RecoCacheService, useValue: { invalidateUser: jest.fn() } },
+        { provide: ChapterLogService, useValue: {} },
+        { provide: ChapterReportService, useValue: {} },
+        { provide: getDataSourceToken(), useValue: { transaction: jest.fn() } },
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+        { provide: getRepositoryToken(UserManga), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<LibraryService>(LibraryService);
+  });
+
+  it('should refresh a stale manga with GREATEST on total_chapters (never regress)', async () => {
+    const staleManga = {
+      mu_id: '42',
+      total_chapters: 100,
+      completed: true,
+      // > 6h → refresh MU déclenché.
+      updated_at: new Date(Date.now() - 7 * 3600 * 1000),
+    };
+    mangasService.returnMangaIfExist.mockResolvedValue(staleManga);
+    // MU annonce un total PLUS BAS (120 → régression regex) : la valeur est
+    // quand même passée en GREATEST, donc jamais de régression en BDD.
+    mangasService.getMangaDetails.mockResolvedValue({
+      muId: 42,
+      title: 'Test Manga',
+      year: 2020,
+      smallCoverUrl: 's.jpg',
+      mediumCoverUrl: 'm.jpg',
+      rating: 7,
+      totalChapters: 120,
+      completed: true,
+      associated: [],
+    });
+
+    await service.checkManga(42);
+
+    const setArg = updateQb.set.mock.calls[0][0];
+    expect(typeof setArg.total_chapters).toBe('function');
+    expect(setArg.total_chapters()).toBe('GREATEST(total_chapters, :newTotal)');
+    expect(updateQb.setParameter).toHaveBeenCalledWith('newTotal', 120);
+    // completed reste écrasé par la valeur MU (design A-5).
+    expect(setArg.completed).toBe(true);
+  });
+});
+
+describe('LibraryService — getMangas (exposition des reports)', () => {
+  let service: LibraryService;
+  let userRepo: { findOne: jest.Mock };
+  let chapterReportService: { getUserReportsByMangaIds: jest.Mock };
+
+  beforeEach(async () => {
+    userRepo = { findOne: jest.fn() };
+    chapterReportService = {
+      getUserReportsByMangaIds: jest.fn().mockResolvedValue(new Map()),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LibraryService,
+        { provide: UserService, useValue: {} },
+        { provide: MangasService, useValue: {} },
+        {
+          provide: UpdateMangaService,
+          useValue: {
+            getMangasIds: jest.fn().mockResolvedValue([42]),
+            checkIfMangaArrayInfoIsOutdated: jest.fn().mockResolvedValue([]),
+          },
+        },
+        { provide: RecoCacheService, useValue: { invalidateUser: jest.fn() } },
+        { provide: ChapterLogService, useValue: {} },
+        { provide: ChapterReportService, useValue: chapterReportService },
+        { provide: getDataSourceToken(), useValue: { transaction: jest.fn() } },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Manga), useValue: {} },
+        { provide: getRepositoryToken(UserManga), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<LibraryService>(LibraryService);
+  });
+
+  it('should expose the effective total and userReportedTotalChapters from the user report', async () => {
+    userRepo.findOne.mockResolvedValue({
+      id: 1,
+      user_mangas: [
+        {
+          manga: {
+            mu_id: '42',
+            title: 'Test Manga',
+            year: 2020,
+            medium_cover_url: 'cover.jpg',
+            rating: 7,
+            total_chapters: 100,
+            associated: [],
+          },
+          user_read_chapters: 90,
+          readingStatus: ReadingStatus.Reading,
+          user_rating: 0,
+          custom_link: null,
+          lastUpdated: new Date(),
+        },
+      ],
+    });
+    chapterReportService.getUserReportsByMangaIds.mockResolvedValue(
+      new Map([['42', 120]]),
+    );
+
+    const result = await service.getMangas(1);
+
+    expect(chapterReportService.getUserReportsByMangaIds).toHaveBeenCalledWith(
+      1,
+      [42],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].totalChapters).toBe(120);
+    expect(result[0].userReportedTotalChapters).toBe(120);
+    expect(result[0].readChapters).toBe(90);
+  });
+});

--- a/src/api/library/library.service.ts
+++ b/src/api/library/library.service.ts
@@ -168,6 +168,14 @@ export class LibraryService {
         ? ReadingStatus.Completed
         : ReadingStatus.CaughtUp;
 
+    // Edge connu (NON corrigé — sur-ingénierie pour le volume actuel) : deux
+    // PUT /library/chapter concurrents pour le même (user, manga) lisent le
+    // MÊME `oldReadChapters` sans SELECT ... FOR UPDATE. Le pointeur converge
+    // (dernier write gagne, applyChapterPointer est monotone), mais le
+    // backfill du journal peut alors journaliser deux fois un intervalle qui
+    // se chevauche (quelques lignes de log dupliquées, jamais de perte de
+    // progression). Un verrou de ligne (FOR UPDATE) sur `oldReadChapters`
+    // serait la vraie parade si le trafic concurrent le justifie un jour.
     const oldReadChapters = mangaToUpdate[0].user_read_chapters;
     await this.persistChapterProgress(
       userId,

--- a/src/api/library/library.service.ts
+++ b/src/api/library/library.service.ts
@@ -6,8 +6,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { UserService } from 'src/api/user/user.service';
-import { Repository } from 'typeorm';
-import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import User from 'src/api/user/user.entity';
 import { Manga } from 'src/api/mangas/manga.entity';
 import { UserManga } from 'src/api/mangas/user-manga.entity';
@@ -23,6 +23,8 @@ import {
   ReadingStatus,
 } from './reading-status.enum';
 import { RecoCacheService } from '@/api/recommendations/reco-cache.service';
+import { ChapterLogService } from './chapter-log.service';
+import { ChapterReportService } from './chapter-report.service';
 
 @Injectable()
 export class LibraryService {
@@ -33,6 +35,10 @@ export class LibraryService {
     private readonly mangasService: MangasService,
     private readonly updateMangaService: UpdateMangaService,
     private readonly recoCache: RecoCacheService,
+    private readonly chapterLogService: ChapterLogService,
+    private readonly chapterReportService: ChapterReportService,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
     @InjectRepository(Manga)
@@ -82,13 +88,20 @@ export class LibraryService {
         this.logger.warn(`Background manga array update failed: ${err}`),
       );
 
+    // Chantier A : reports « plus de chapitres » de l'user (1 requête IN,
+    // pas de N+1) — exposés via totalChapters effectif dans le DTO.
+    const reports = await this.chapterReportService.getUserReportsByMangaIds(
+      userId,
+      mangaIds,
+    );
+
     return user.user_mangas
       .slice()
       .sort(
         (a, b) =>
           new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime(),
       )
-      .map((a) => MangaQuickViewDto.fromLibrary(a));
+      .map((a) => MangaQuickViewDto.fromLibrary(a, reports.get(a.manga.mu_id)));
   }
 
   async deleteManga(userId: number, muId: number): Promise<boolean> {
@@ -136,33 +149,116 @@ export class LibraryService {
 
     const mangaEntity = await this.checkManga(muId);
 
-    if (readChapters > mangaEntity.total_chapters)
+    // Chantier A : cap 406 sur le total EFFECTIF = max(officiel, report).
+    const effectiveTotal = await this.chapterReportService.getEffectiveTotal(
+      userId,
+      muId,
+      mangaEntity.total_chapters,
+    );
+
+    if (readChapters > effectiveTotal)
       throw new ChapterException(
-        `${readChapters} (new value) is above ${mangaEntity.total_chapters} (total number of chapters)`,
+        `${readChapters} (new value) is above ${effectiveTotal} (effective total number of chapters)`,
       );
 
-    const allAvailableChaptersReadStatus = mangaEntity.completed
-      ? ReadingStatus.Completed
-      : ReadingStatus.CaughtUp;
+    const readingStatus =
+      readChapters < effectiveTotal
+        ? ReadingStatus.Reading
+        : mangaEntity.completed
+        ? ReadingStatus.Completed
+        : ReadingStatus.CaughtUp;
 
-    await this.userMangaRepository
-      .createQueryBuilder()
+    const oldReadChapters = mangaToUpdate[0].user_read_chapters;
+    await this.persistChapterProgress(
+      userId,
+      muId,
+      readChapters,
+      readingStatus,
+      oldReadChapters,
+    );
+
+    // La progression influe sur le scoring des recos (statut/récence).
+    this.recoCache.invalidateUser(userId);
+    return true;
+  }
+
+  /**
+   * Chantier B : écrit le pointeur et, si la progression AVANCE, backfill
+   * le journal (oldRead+1..readChapters) dans la même transaction.
+   * Décrément/no-op (B-4) : journal additif, seul le pointeur bouge.
+   * Fallback séquentiel : si la transaction échoue, le pointeur prime —
+   * UPDATE seul puis backfill best-effort (logger.warn).
+   */
+  private async persistChapterProgress(
+    userId: number,
+    muId: number,
+    readChapters: number,
+    readingStatus: ReadingStatus,
+    oldReadChapters: number,
+  ): Promise<void> {
+    if (readChapters <= oldReadChapters) {
+      await this.applyChapterPointer(userId, muId, readChapters, readingStatus);
+      return;
+    }
+
+    try {
+      await this.dataSource.transaction(async (manager) => {
+        await this.applyChapterPointer(
+          userId,
+          muId,
+          readChapters,
+          readingStatus,
+          manager,
+        );
+        await this.chapterLogService.recordBackfill(
+          userId,
+          muId,
+          oldReadChapters,
+          readChapters,
+          manager,
+        );
+      });
+    } catch (err) {
+      this.logger.warn(
+        `updateChapter transaction failed for user ${userId} manga ${muId} — sequential fallback: ${err}`,
+      );
+      await this.applyChapterPointer(userId, muId, readChapters, readingStatus);
+      try {
+        await this.chapterLogService.recordBackfill(
+          userId,
+          muId,
+          oldReadChapters,
+          readChapters,
+        );
+      } catch (backfillErr) {
+        this.logger.warn(
+          `Chapter log backfill failed for user ${userId} manga ${muId}: ${backfillErr}`,
+        );
+      }
+    }
+  }
+
+  /** UPDATE du pointeur de progression (transactionnel si manager fourni). */
+  private async applyChapterPointer(
+    userId: number,
+    muId: number,
+    readChapters: number,
+    readingStatus: ReadingStatus,
+    manager?: EntityManager,
+  ): Promise<void> {
+    const queryBuilder = manager
+      ? manager.createQueryBuilder()
+      : this.userMangaRepository.createQueryBuilder();
+    await queryBuilder
       .update(UserManga)
       .set({
         user_read_chapters: readChapters,
-        readingStatus:
-          readChapters < mangaEntity.total_chapters
-            ? ReadingStatus.Reading
-            : allAvailableChaptersReadStatus,
+        readingStatus,
         lastUpdated: new Date(),
       })
       .where('user_id = :id', { id: userId })
       .andWhere('manga_id = :muId', { muId: muId.toString() })
       .execute();
-
-    // La progression influe sur le scoring des recos (statut/récence).
-    this.recoCache.invalidateUser(userId);
-    return true;
   }
 
   async updateReadingStatus(
@@ -231,13 +327,16 @@ export class LibraryService {
         await this.mangasService.getMangaDetails(muId),
       );
 
+      // A-5 : GREATEST inconditionnel — total_chapters ne régresse jamais
+      // (regex status MU peu fiable, cf. decisions.md). completed écrasé.
       await this.mangaRepository
         .createQueryBuilder()
         .update(Manga)
         .set({
           completed: mangaDetails.completed,
-          total_chapters: mangaDetails.total_chapters,
+          total_chapters: () => 'GREATEST(total_chapters, :newTotal)',
         })
+        .setParameter('newTotal', Number(mangaDetails.total_chapters) || 0)
         .where('mu_id = :muId', { muId: muId.toString() })
         .execute();
     }
@@ -252,35 +351,33 @@ export class LibraryService {
     });
   }
 
-  async updateCustomLink(
+  /** Charge l'entrée bibliothèque (user, manga) ou throw 404. */
+  private async findUserMangaOrThrow(
     userId: number,
     muId: number,
-    customLink: string,
-  ): Promise<boolean> {
-    const userManga = await this.userMangaRepository.findOne({
-      where: { user: { id: userId }, manga: { mu_id: muId.toString() } },
-      relations: ['user', 'manga'],
-    });
+  ): Promise<UserManga> {
+    const userManga = await this.getUserManga(userId, muId);
     if (!userManga) {
       throw new NotFoundException(
         `No manga found in user library for userId: ${userId} and muId: ${muId}`,
       );
     }
+    return userManga;
+  }
+
+  async updateCustomLink(
+    userId: number,
+    muId: number,
+    customLink: string,
+  ): Promise<boolean> {
+    const userManga = await this.findUserMangaOrThrow(userId, muId);
     userManga.custom_link = customLink;
     await this.userMangaRepository.save(userManga);
     return true;
   }
 
   async deleteCustomLink(userId: number, muId: number): Promise<boolean> {
-    const userManga = await this.userMangaRepository.findOne({
-      where: { user: { id: userId }, manga: { mu_id: muId.toString() } },
-      relations: ['user', 'manga'],
-    });
-    if (!userManga) {
-      throw new NotFoundException(
-        `No manga found in user library for userId: ${userId} and muId: ${muId}`,
-      );
-    }
+    const userManga = await this.findUserMangaOrThrow(userId, muId);
     userManga.custom_link = null;
     await this.userMangaRepository.save(userManga);
     return true;
@@ -291,15 +388,7 @@ export class LibraryService {
     muId: number,
     rating: number,
   ): Promise<boolean> {
-    const userManga = await this.userMangaRepository.findOne({
-      where: { user: { id: userId }, manga: { mu_id: muId.toString() } },
-      relations: ['user', 'manga'],
-    });
-    if (!userManga) {
-      throw new NotFoundException(
-        `No manga found in user library for userId: ${userId} and muId: ${muId}`,
-      );
-    }
+    const userManga = await this.findUserMangaOrThrow(userId, muId);
     userManga.user_rating = rating;
     userManga.lastUpdated = new Date();
     await this.userMangaRepository.save(userManga);

--- a/src/api/library/manga-chapter-report.entity.ts
+++ b/src/api/library/manga-chapter-report.entity.ts
@@ -1,0 +1,53 @@
+import User from '@/api/user/user.entity';
+import { Manga } from '@/api/mangas/manga.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Signalement « ce manga a plus de chapitres que le total connu » (Chantier A).
+ *
+ * La ligne EST l'override par user : le total effectif d'un user est
+ * `max(manga.total_chapters, reported_total)`. Pas de colonne override sur
+ * `manga` — le cap 406 reste en place (garde-fou anti-typo) mais s'applique
+ * au total effectif, borné à `total + MAX_REPORT_DELTA`.
+ *
+ * Consolidation communautaire : quand ≥ MIN_REPORTERS users distincts
+ * signalent un total > total officiel, `manga.total_chapters` est bumpé au
+ * MIN des totaux signalés concordants, puis les reports couverts sont purgés
+ * (voir `ChapterReportService.consolidate`).
+ *
+ * Contrainte d'unicité (user, manga) : un user n'a qu'un report actif par
+ * manga — un nouveau report écrase le précédent (upsert).
+ */
+@Entity('manga_chapter_report')
+@Unique('UQ_chapter_report_user_manga', ['user', 'manga'])
+export class MangaChapterReport {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', nullable: false })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Manga, { onDelete: 'CASCADE', nullable: false })
+  @JoinColumn({ name: 'manga_id', referencedColumnName: 'mu_id' })
+  manga: Manga;
+
+  /** Total de chapitres signalé par l'user (strictement > total officiel). */
+  @Column({ type: 'int', nullable: false })
+  reported_total: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+}

--- a/src/api/library/user-throttler.guard.spec.ts
+++ b/src/api/library/user-throttler.guard.spec.ts
@@ -1,0 +1,33 @@
+import { UserThrottlerGuard } from './user-throttler.guard';
+
+/** Accès typé au membre protégé `getTracker` sans recourir à `any`. */
+type TrackerAccess = {
+  getTracker(req: Record<string, unknown>): Promise<string>;
+};
+
+describe('UserThrottlerGuard', () => {
+  let guard: UserThrottlerGuard;
+
+  beforeEach(() => {
+    // getTracker n'utilise ni les options ni le storage : instanciation
+    // directe avec des dépendances factices.
+    guard = new UserThrottlerGuard([], {} as never, {} as never);
+  });
+
+  it("tracke par userId quand req.user est présent (bucket par utilisateur, pas l'IP du proxy)", async () => {
+    const tracker = await (guard as unknown as TrackerAccess).getTracker({
+      user: { id: 42 },
+      ip: '10.0.0.1',
+    });
+
+    expect(tracker).toBe('user-42');
+  });
+
+  it("retombe sur l'IP quand aucun user n'est authentifié (cas défensif)", async () => {
+    const tracker = await (guard as unknown as TrackerAccess).getTracker({
+      ip: '10.0.0.1',
+    });
+
+    expect(tracker).toBe('10.0.0.1');
+  });
+});

--- a/src/api/library/user-throttler.guard.ts
+++ b/src/api/library/user-throttler.guard.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+/**
+ * Forme minimale de la requête HTTP exploitée par le tracker.
+ * `user` est injecté par `JwtAuthGuard` (passport) ; `ip` est le fallback.
+ */
+interface ThrottledRequest {
+  user?: { id?: number | string };
+  ip?: string;
+}
+
+/**
+ * Garde de rate-limiting PAR UTILISATEUR pour la route de signalement
+ * `report-chapters`.
+ *
+ * Pourquoi un garde dédié plutôt que `@Throttle()` + `ThrottlerGuard` global :
+ * l'API tourne derrière le reverse proxy NPMplus, donc `req.ip` vaut l'IP du
+ * proxy pour TOUS les utilisateurs. Un `@Throttle({ limit: 10, ttl: 1h })`
+ * tracké par IP devient alors un budget GLOBAL de 10/h partagé (déni de
+ * service mutuel : 10 signalements par heure pour l'ensemble des users).
+ *
+ * Ce garde :
+ *  - définit son PROPRE throttler nommé `report-chapters`, isolé du `default`
+ *    global (clé de comptage distincte) — le `ThrottlerGuard` global
+ *    (APP_GUARD) n'applique donc jamais cette limite stricte par IP ;
+ *  - tracke par `req.user.id` (fallback IP défensif si non authentifié).
+ *
+ * IMPORTANT : à placer APRÈS `JwtAuthGuard` dans `@UseGuards(...)` pour que
+ * `req.user` soit renseigné. Les gardes de route s'exécutent dans l'ordre
+ * déclaré ; le garde global, lui, s'exécute AVANT l'auth (ordre NestJS :
+ * global → class → method) et ne verrait jamais `req.user`.
+ */
+@Injectable()
+export class UserThrottlerGuard extends ThrottlerGuard {
+  /** Fenêtre de 1 h (ms) du garde-fou anti-abus. */
+  private static readonly WINDOW_MS = 3_600_000;
+
+  /** Quota : 10 signalements par fenêtre et par utilisateur. */
+  private static readonly LIMIT = 10;
+
+  /** Nom du throttler dédié — distinct du `default` global. */
+  private static readonly THROTTLER_NAME = 'report-chapters';
+
+  async onModuleInit(): Promise<void> {
+    // Réutilise le binding de base (commonOptions.getTracker = notre override
+    // ci-dessous, par polymorphisme), puis remplace les throttlers injectés
+    // (module `default`, 100/min) par un throttler dédié self-contained.
+    await super.onModuleInit();
+    this.throttlers = [
+      {
+        name: UserThrottlerGuard.THROTTLER_NAME,
+        ttl: UserThrottlerGuard.WINDOW_MS,
+        limit: UserThrottlerGuard.LIMIT,
+      },
+    ];
+  }
+
+  /**
+   * Clé de rate-limit = `user-<id>` (bucket par utilisateur) ; fallback sur
+   * l'IP si aucun user (route protégée par `JwtAuthGuard` → cas défensif).
+   */
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const { user, ip } = req as ThrottledRequest;
+    const userId = user?.id;
+    if (userId !== undefined && userId !== null) {
+      return `user-${userId}`;
+    }
+    return ip ?? 'unknown';
+  }
+}

--- a/src/api/mangas/catalog-sync-state.entity.ts
+++ b/src/api/mangas/catalog-sync-state.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Statuts possibles d'un run de synchronisation catalogue.
+ * - `completed` : la passe a atteint sa dernière page (curseur remis à 0).
+ * - `partial`   : arrêt propre en cours de passe (budget épuisé ou échec MU
+ *                 persistant) — le curseur est conservé pour reprise.
+ * - `failed`    : réservé aux erreurs fatales inattendues.
+ */
+export type CatalogSyncRunStatus = 'completed' | 'partial' | 'failed';
+
+/**
+ * Jobs suivis :
+ * - `catalog:rating`   : passe principale nightly (orderby=rating).
+ * - `catalog:week_pos` : passe hebdomadaire du dimanche (orderby=week_pos).
+ * - `hydration`        : hydratation des genres manquants via getMangaDetails.
+ */
+export type CatalogSyncJobName =
+  | 'catalog:rating'
+  | 'catalog:week_pos'
+  | 'hydration';
+
+/**
+ * Curseur persistant de la synchronisation nightly du catalogue MangaUpdates
+ * (CatalogSyncService). Une ligne par job — permet la reprise après un arrêt
+ * partiel (rate-limit MU, redémarrage du process) sans re-parcourir les pages
+ * déjà ingérées.
+ */
+@Entity('catalog_sync_state')
+export class CatalogSyncState {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  job_name: string;
+
+  /** Dernière page MU ingérée avec succès (0 = passe pas commencée). */
+  @Column({ default: 0 })
+  last_completed_page: number;
+
+  /** Nombre total de pages de la passe (connu après la 1ʳᵉ réponse MU). */
+  @Column({ type: 'int', nullable: true })
+  total_pages: number | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  last_run_at: Date | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  last_run_status: CatalogSyncRunStatus | null;
+
+  /** Nombre d'échecs consécutifs (remis à 0 sur passe complétée). */
+  @Column({ default: 0 })
+  consecutive_failures: number;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/api/mangas/catalog-sync.mapper.ts
+++ b/src/api/mangas/catalog-sync.mapper.ts
@@ -27,29 +27,52 @@ export interface CatalogPage {
   totalHits: number;
 }
 
-export interface CatalogUpsertRows {
-  /** Lignes dont le payload MU contient des genres exploitables. */
-  withGenres: Array<QueryDeepPartialEntity<Manga>>;
-  /** Lignes sans genres — upsertées SANS la colonne `genres`. */
-  withoutGenres: Array<QueryDeepPartialEntity<Manga>>;
+export interface CatalogUpsertBatch {
+  /**
+   * Colonnes du `ON CONFLICT DO UPDATE SET` — jamais une colonne à null, pour
+   * ne pas écraser une valeur déjà hydratée en base par un null MU.
+   */
+  overwrite: string[];
+  /** Lignes partageant exactement ce jeu de colonnes non-null. */
+  rows: Array<QueryDeepPartialEntity<Manga>>;
 }
 
+/** Toujours écrasée : MU search fournit toujours un titre. */
+const ALWAYS_OVERWRITE_COLUMNS = ['title'] as const;
+
 /**
- * Mappe les records d'une page search MU vers des lignes d'upsert `manga`,
- * séparées en deux lots (avec / sans genres) pour que le lot sans genres
- * n'écrase jamais des genres existants par null. Les records sans
- * `series_id` exploitable sont ignorés.
+ * Colonnes nullable protégées : elles ne sont écrasées QUE si le record MU
+ * fournit une valeur non-null. Un record search sans `bayesian_rating`
+ * (fréquent en `week_pos`) ne doit pas remettre à null une note déjà hydratée
+ * (le manga sortirait de `CatalogCandidateService` rating>=7 / `findSleeperHits`).
+ * Idem pour l'année et les covers (et les genres, historiquement protégés).
  */
-export function buildCatalogUpsertRows(
+const PROTECTED_NULLABLE_COLUMNS = [
+  'year',
+  'rating',
+  'small_cover_url',
+  'medium_cover_url',
+  'genres',
+] as const;
+
+/**
+ * Mappe les records d'une page search MU vers des lots d'upsert `manga`,
+ * regroupés par jeu de colonnes NON-NULL. Chaque lot ne liste dans son
+ * `overwrite` que les colonnes réellement renseignées → une colonne absente
+ * du payload n'écrase jamais la valeur existante par null (protection
+ * généralisée à rating/year/covers, pas seulement aux genres). Les records
+ * sans `series_id` exploitable sont ignorés.
+ */
+export function buildCatalogUpsertBatches(
   records: MuSearchResult[],
-): CatalogUpsertRows {
-  const withGenres: Array<QueryDeepPartialEntity<Manga>> = [];
-  const withoutGenres: Array<QueryDeepPartialEntity<Manga>> = [];
+): CatalogUpsertBatch[] {
+  const batches = new Map<string, CatalogUpsertBatch>();
 
   for (const item of records) {
     const record = item?.record;
     const seriesId = Number(record?.series_id);
     if (!record || !Number.isFinite(seriesId) || seriesId <= 0) continue;
+
     const genres = normalizeGenres(record.genres);
     const yearNum = Number.parseInt(String(record.year ?? ''), 10);
     const row: QueryDeepPartialEntity<Manga> = {
@@ -63,11 +86,22 @@ export function buildCatalogUpsertRows(
       small_cover_url: record.image?.url?.thumb ?? null,
       medium_cover_url: record.image?.url?.original ?? null,
     };
-    if (genres && genres.length > 0) withGenres.push({ ...row, genres });
-    else withoutGenres.push(row);
+    if (genres && genres.length > 0) row.genres = genres;
+
+    // Overwrite = colonnes toujours écrasées + colonnes protégées non-null.
+    const rowFields = row as Record<string, unknown>;
+    const overwrite = [
+      ...ALWAYS_OVERWRITE_COLUMNS,
+      ...PROTECTED_NULLABLE_COLUMNS.filter((col) => rowFields[col] != null),
+    ];
+
+    const key = overwrite.join(',');
+    const batch = batches.get(key);
+    if (batch) batch.rows.push(row);
+    else batches.set(key, { overwrite, rows: [row] });
   }
 
-  return { withGenres, withoutGenres };
+  return [...batches.values()];
 }
 
 /** Lit un entier > 0 depuis la config, sinon retourne le défaut. */

--- a/src/api/mangas/catalog-sync.mapper.ts
+++ b/src/api/mangas/catalog-sync.mapper.ts
@@ -1,0 +1,81 @@
+import { ConfigService } from '@nestjs/config';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { normalizeGenres } from './genre.utils';
+import { Manga } from './manga.entity';
+
+/** Item du payload search MU (`/series/search`). */
+export interface MuSearchResult {
+  record?: {
+    series_id?: number | string;
+    title?: string;
+    year?: string | number;
+    bayesian_rating?: number | null;
+    image?: {
+      url?: { original?: string | null; thumb?: string | null } | null;
+    } | null;
+    genres?: unknown;
+  };
+}
+
+export interface MuSearchBody {
+  results?: MuSearchResult[];
+  total_hits?: number;
+}
+
+export interface CatalogPage {
+  records: MuSearchResult[];
+  totalHits: number;
+}
+
+export interface CatalogUpsertRows {
+  /** Lignes dont le payload MU contient des genres exploitables. */
+  withGenres: Array<QueryDeepPartialEntity<Manga>>;
+  /** Lignes sans genres — upsertées SANS la colonne `genres`. */
+  withoutGenres: Array<QueryDeepPartialEntity<Manga>>;
+}
+
+/**
+ * Mappe les records d'une page search MU vers des lignes d'upsert `manga`,
+ * séparées en deux lots (avec / sans genres) pour que le lot sans genres
+ * n'écrase jamais des genres existants par null. Les records sans
+ * `series_id` exploitable sont ignorés.
+ */
+export function buildCatalogUpsertRows(
+  records: MuSearchResult[],
+): CatalogUpsertRows {
+  const withGenres: Array<QueryDeepPartialEntity<Manga>> = [];
+  const withoutGenres: Array<QueryDeepPartialEntity<Manga>> = [];
+
+  for (const item of records) {
+    const record = item?.record;
+    const seriesId = Number(record?.series_id);
+    if (!record || !Number.isFinite(seriesId) || seriesId <= 0) continue;
+    const genres = normalizeGenres(record.genres);
+    const yearNum = Number.parseInt(String(record.year ?? ''), 10);
+    const row: QueryDeepPartialEntity<Manga> = {
+      mu_id: String(seriesId),
+      title: record.title || `Manga ${seriesId}`,
+      year: Number.isFinite(yearNum) ? yearNum : null,
+      rating:
+        typeof record.bayesian_rating === 'number'
+          ? record.bayesian_rating
+          : null,
+      small_cover_url: record.image?.url?.thumb ?? null,
+      medium_cover_url: record.image?.url?.original ?? null,
+    };
+    if (genres && genres.length > 0) withGenres.push({ ...row, genres });
+    else withoutGenres.push(row);
+  }
+
+  return { withGenres, withoutGenres };
+}
+
+/** Lit un entier > 0 depuis la config, sinon retourne le défaut. */
+export function intFromConfig(
+  config: ConfigService,
+  key: string,
+  fallback: number,
+): number {
+  const value = Number(config.get<string>(key));
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/src/api/mangas/catalog-sync.service.spec.ts
+++ b/src/api/mangas/catalog-sync.service.spec.ts
@@ -340,6 +340,75 @@ describe('CatalogSyncService', () => {
       expect(insertCalls[0].orUpdateCols).not.toContain('genres');
       expect(insertCalls[0].values).toHaveLength(3);
     });
+
+    it("n'écrase JAMAIS rating/year/covers par null (record search sans bayesian_rating)", async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      // Record MU minimal : pas de year, pas de bayesian_rating, pas d'image.
+      const page = {
+        data: {
+          total_hits: 1,
+          results: [
+            {
+              record: {
+                series_id: 5000,
+                title: 'Sleeper Hit',
+                genres: [{ genre: 'Action' }],
+              },
+            },
+          ],
+        },
+      };
+      postMock.mockReturnValue(of(page));
+
+      await service.runOnce('catalog:rating');
+
+      expect(insertCalls).toHaveLength(1);
+      const cols = insertCalls[0].orUpdateCols;
+      // title + genres (non-null) restent écrasables ; rating/year/covers sont
+      // OMIS → une note/année/cover déjà hydratée en base n'est pas remise à
+      // null par ce record search incomplet.
+      expect(cols).toContain('title');
+      expect(cols).toContain('genres');
+      expect(cols).not.toContain('rating');
+      expect(cols).not.toContain('year');
+      expect(cols).not.toContain('small_cover_url');
+      expect(cols).not.toContain('medium_cover_url');
+      // L'INSERT initial garde bien null (colonnes nullable).
+      expect(insertCalls[0].values[0].rating).toBeNull();
+      expect(insertCalls[0].values[0].year).toBeNull();
+    });
+  });
+
+  describe('erreur DB (arrêt propre)', () => {
+    it("une erreur d'upsert → statut partial, failures++, curseur conservé, PAS de propagation", async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({
+          last_completed_page: 0,
+          total_pages: 2,
+          consecutive_failures: 0,
+        }),
+      );
+      postMock.mockImplementation((_url: string, payload: { page: number }) =>
+        of(muPage(payload.page * 1000, 100, 200)),
+      );
+      // L'upsert (QB sans alias) rejette ; le select (QB avec alias) reste ok.
+      mangaRepo.createQueryBuilder.mockImplementation((alias?: string) => {
+        if (alias) return selectQb;
+        const qb = makeInsertQb();
+        qb.execute = jest.fn().mockRejectedValue(new Error('DB down'));
+        return qb;
+      });
+
+      // Ne doit pas rejeter (sinon les passes suivantes du run sauteraient).
+      await expect(service.runOnce('catalog:rating')).resolves.toBeUndefined();
+
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_run_status).toBe('partial');
+      expect(final.consecutive_failures).toBe(1);
+      expect(final.last_completed_page).toBe(0); // curseur conservé
+    });
   });
 
   describe('hydrateMissingGenres', () => {

--- a/src/api/mangas/catalog-sync.service.spec.ts
+++ b/src/api/mangas/catalog-sync.service.spec.ts
@@ -1,0 +1,441 @@
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { of, throwError } from 'rxjs';
+import { CatalogSyncService } from './catalog-sync.service';
+import { CatalogSyncState } from './catalog-sync-state.entity';
+import { Manga } from './manga.entity';
+import { MangasService } from './mangas.service';
+
+/** Réponse MU search : `count` records à partir de `firstId`. */
+function muPage(
+  firstId: number,
+  count: number,
+  totalHits: number,
+  opts?: { withGenres?: boolean },
+) {
+  const withGenres = opts?.withGenres ?? true;
+  return {
+    data: {
+      total_hits: totalHits,
+      results: Array.from({ length: count }, (_, i) => ({
+        record: {
+          series_id: firstId + i,
+          title: `Manga ${firstId + i}`,
+          year: '2020',
+          bayesian_rating: 8.1,
+          image: {
+            url: {
+              original: `https://cdn/${firstId + i}.jpg`,
+              thumb: `https://cdn/${firstId + i}-t.jpg`,
+            },
+          },
+          genres: withGenres ? [{ genre: 'Action' }] : undefined,
+        },
+      })),
+    },
+  };
+}
+
+function axiosError(status: number) {
+  return {
+    isAxiosError: true,
+    message: `Request failed with status code ${status}`,
+    response: { status },
+  };
+}
+
+interface InsertCall {
+  values: Array<Record<string, unknown>>;
+  orUpdateCols: string[];
+}
+
+describe('CatalogSyncService', () => {
+  let service: CatalogSyncService;
+  let postMock: jest.Mock;
+  let stateRepo: {
+    findOneBy: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+  };
+  let mangaRepo: { createQueryBuilder: jest.Mock };
+  let mangasService: { getMangaDetails: jest.Mock };
+  let insertCalls: InsertCall[];
+  let selectQb: {
+    where: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    getMany: jest.Mock;
+  };
+  let sleepMock: jest.Mock;
+
+  /** État persistant simulé (dernier `save` par job_name). */
+  let savedStates: Array<Record<string, unknown>>;
+
+  function makeState(
+    overrides: Partial<CatalogSyncState> = {},
+  ): CatalogSyncState {
+    const state = new CatalogSyncState();
+    state.id = 1;
+    state.job_name = 'catalog:rating';
+    state.last_completed_page = 0;
+    state.total_pages = null;
+    state.last_run_at = null;
+    state.last_run_status = null;
+    state.consecutive_failures = 0;
+    return Object.assign(state, overrides);
+  }
+
+  function makeInsertQb() {
+    const captured: Partial<InsertCall> = {};
+    const qb = {
+      insert: jest.fn(() => qb),
+      into: jest.fn(() => qb),
+      values: jest.fn((v: Array<Record<string, unknown>>) => {
+        captured.values = v;
+        return qb;
+      }),
+      orUpdate: jest.fn((cols: string[]) => {
+        captured.orUpdateCols = cols;
+        return qb;
+      }),
+      execute: jest.fn(() => {
+        insertCalls.push({
+          values: captured.values ?? [],
+          orUpdateCols: captured.orUpdateCols ?? [],
+        });
+        return Promise.resolve({});
+      }),
+    };
+    return qb;
+  }
+
+  beforeEach(async () => {
+    insertCalls = [];
+    savedStates = [];
+    postMock = jest.fn();
+    sleepMock = jest.fn().mockResolvedValue(undefined);
+
+    stateRepo = {
+      findOneBy: jest.fn().mockResolvedValue(null),
+      create: jest.fn((partial: Partial<CatalogSyncState>) =>
+        makeState(partial),
+      ),
+      save: jest.fn((s: CatalogSyncState) => {
+        savedStates.push({ ...s });
+        return Promise.resolve(s);
+      }),
+    };
+
+    selectQb = {
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+
+    mangaRepo = {
+      // Sans alias → chaîne insert/upsert ; avec alias ('m') → select.
+      createQueryBuilder: jest.fn((alias?: string) =>
+        alias ? selectQb : makeInsertQb(),
+      ),
+    };
+
+    mangasService = { getMangaDetails: jest.fn().mockResolvedValue({}) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CatalogSyncService,
+        { provide: HttpService, useValue: { post: postMock } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'NODE_ENV' ? 'test' : undefined,
+            ),
+          },
+        },
+        { provide: getRepositoryToken(CatalogSyncState), useValue: stateRepo },
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+        { provide: MangasService, useValue: mangasService },
+      ],
+    }).compile();
+
+    service = module.get<CatalogSyncService>(CatalogSyncService);
+    service.sleep = sleepMock;
+  });
+
+  describe('pagination / reprise', () => {
+    it('reprend au curseur persisté et complète la passe (curseur remis à 0, statut completed)', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 2, total_pages: 4 }),
+      );
+      // 400 hits / perpage 100 → 4 pages au total.
+      postMock.mockImplementation((_url: string, payload: { page: number }) =>
+        of(muPage(payload.page * 1000, 100, 400)),
+      );
+
+      await service.runOnce('catalog:rating');
+
+      // Reprise : pages 3 et 4 uniquement.
+      expect(postMock).toHaveBeenCalledTimes(2);
+      const pages = postMock.mock.calls.map((c) => c[1].page);
+      expect(pages).toEqual([3, 4]);
+      // Payload conforme : orderby=rating, perpage=100, NSFW exclus.
+      const payload = postMock.mock.calls[0][1];
+      expect(payload.orderby).toBe('rating');
+      expect(payload.perpage).toBe(100);
+      expect(payload.exclude_genre).toContain('Hentai');
+
+      // État final : passe complétée, curseur remis à 0.
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_completed_page).toBe(0);
+      expect(final.last_run_status).toBe('completed');
+      expect(final.consecutive_failures).toBe(0);
+    });
+
+    it("s'arrête au budget PAGES_PER_RUN en conservant le curseur (statut partial)", async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CatalogSyncService,
+          { provide: HttpService, useValue: { post: postMock } },
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string) => {
+                if (key === 'CATALOG_SYNC_PAGES_PER_RUN') return '2';
+                return key === 'NODE_ENV' ? 'test' : undefined;
+              }),
+            },
+          },
+          {
+            provide: getRepositoryToken(CatalogSyncState),
+            useValue: stateRepo,
+          },
+          { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+          { provide: MangasService, useValue: mangasService },
+        ],
+      }).compile();
+      const budgeted = module.get<CatalogSyncService>(CatalogSyncService);
+      budgeted.sleep = sleepMock;
+
+      stateRepo.findOneBy.mockResolvedValue(makeState());
+      postMock.mockImplementation((_url: string, payload: { page: number }) =>
+        of(muPage(payload.page * 1000, 100, 1000)),
+      );
+
+      await budgeted.runOnce('catalog:rating');
+
+      // Budget 2 pages sur 10 → arrêt propre, curseur conservé.
+      expect(postMock).toHaveBeenCalledTimes(2);
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_completed_page).toBe(2);
+      expect(final.last_run_status).toBe('partial');
+    });
+  });
+
+  describe('backoff / arrêt partiel', () => {
+    it('429 persistant : 4 retries (5/10/20/40 s) puis partial, curseur conservé, failures++', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({
+          last_completed_page: 1,
+          total_pages: 3,
+          consecutive_failures: 1,
+        }),
+      );
+      postMock.mockImplementation(() => throwError(() => axiosError(429)));
+
+      await service.runOnce('catalog:rating');
+
+      // 1 tentative initiale + 4 retries.
+      expect(postMock).toHaveBeenCalledTimes(5);
+      expect(sleepMock).toHaveBeenCalledWith(5_000);
+      expect(sleepMock).toHaveBeenCalledWith(10_000);
+      expect(sleepMock).toHaveBeenCalledWith(20_000);
+      expect(sleepMock).toHaveBeenCalledWith(40_000);
+
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_completed_page).toBe(1); // curseur conservé
+      expect(final.last_run_status).toBe('partial');
+      expect(final.consecutive_failures).toBe(2);
+      // Rien n'a été upserté.
+      expect(insertCalls).toHaveLength(0);
+    });
+
+    it('reprend le backoff sur 5xx puis réussit (pas de partial)', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      postMock
+        .mockImplementationOnce(() => throwError(() => axiosError(503)))
+        .mockImplementation(() => of(muPage(1000, 100, 100)));
+
+      await service.runOnce('catalog:rating');
+
+      expect(postMock).toHaveBeenCalledTimes(2);
+      expect(sleepMock).toHaveBeenCalledWith(5_000);
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_run_status).toBe('completed');
+    });
+
+    it('erreur non-retryable (400) : arrêt partiel immédiat sans retry', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 2 }),
+      );
+      postMock.mockImplementation(() => throwError(() => axiosError(400)));
+
+      await service.runOnce('catalog:rating');
+
+      expect(postMock).toHaveBeenCalledTimes(1);
+      const final = savedStates[savedStates.length - 1];
+      expect(final.last_run_status).toBe('partial');
+      expect(final.consecutive_failures).toBe(1);
+    });
+  });
+
+  describe('upsert en 2 lots (genres)', () => {
+    it('sépare les records avec/sans genres — le 2e lot omet la colonne genres', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      const page = {
+        data: {
+          total_hits: 2,
+          results: [
+            muPage(1000, 1, 2).data.results[0], // avec genres
+            muPage(2000, 1, 2, { withGenres: false }).data.results[0], // sans
+          ],
+        },
+      };
+      postMock.mockReturnValue(of(page));
+
+      await service.runOnce('catalog:rating');
+
+      expect(insertCalls).toHaveLength(2);
+      const [avecGenres, sansGenres] = insertCalls;
+      expect(avecGenres.orUpdateCols).toContain('genres');
+      expect(avecGenres.values[0].mu_id).toBe('1000');
+      expect(avecGenres.values[0].genres).toEqual(['Action']);
+      // Le lot sans genres n'update PAS la colonne genres (jamais écrasée
+      // par null) ni total_chapters/completed/associated.
+      expect(sansGenres.orUpdateCols).not.toContain('genres');
+      expect(sansGenres.values[0].mu_id).toBe('2000');
+      for (const call of insertCalls) {
+        expect(call.orUpdateCols).not.toContain('total_chapters');
+        expect(call.orUpdateCols).not.toContain('completed');
+        expect(call.orUpdateCols).not.toContain('associated');
+      }
+    });
+
+    it('payload entièrement sans genres → un seul lot, sans la colonne genres', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      postMock.mockReturnValue(of(muPage(1000, 3, 3, { withGenres: false })));
+
+      await service.runOnce('catalog:rating');
+
+      expect(insertCalls).toHaveLength(1);
+      expect(insertCalls[0].orUpdateCols).not.toContain('genres');
+      expect(insertCalls[0].values).toHaveLength(3);
+    });
+  });
+
+  describe('hydrateMissingGenres', () => {
+    function stub(muId: string): Manga {
+      const manga = new Manga();
+      manga.mu_id = muId;
+      manga.title = `Stub ${muId}`;
+      return manga;
+    }
+
+    it('applique le budget en LIMIT SQL et hydrate via getMangaDetails', async () => {
+      selectQb.getMany.mockResolvedValue([stub('100'), stub('200')]);
+
+      const hydrated = await service.hydrateMissingGenres(2);
+
+      expect(selectQb.limit).toHaveBeenCalledWith(2);
+      expect(mangasService.getMangaDetails).toHaveBeenCalledTimes(2);
+      expect(mangasService.getMangaDetails).toHaveBeenCalledWith(100);
+      expect(mangasService.getMangaDetails).toHaveBeenCalledWith(200);
+      expect(hydrated).toBe(2);
+      // Rythme : 1 appel / delayMs (défaut 2000 ms).
+      expect(sleepMock).toHaveBeenCalledWith(2000);
+    });
+
+    it('budget par défaut = CATALOG_SYNC_HYDRATION_BUDGET (200)', async () => {
+      selectQb.getMany.mockResolvedValue([]);
+      await service.hydrateMissingGenres();
+      expect(selectQb.limit).toHaveBeenCalledWith(200);
+    });
+
+    it("un échec getMangaDetails n'interrompt pas la boucle", async () => {
+      selectQb.getMany.mockResolvedValue([stub('100'), stub('200')]);
+      mangasService.getMangaDetails
+        .mockRejectedValueOnce(new Error('MU down'))
+        .mockResolvedValueOnce({});
+
+      const hydrated = await service.hydrateMissingGenres(2);
+
+      expect(mangasService.getMangaDetails).toHaveBeenCalledTimes(2);
+      expect(hydrated).toBe(1);
+    });
+  });
+
+  describe('anti-réentrance', () => {
+    it('un runOnce concurrent est ignoré tant que le premier est en cours', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      postMock.mockReturnValue(of(muPage(1000, 100, 100)));
+
+      await Promise.all([
+        service.runOnce('catalog:rating'),
+        service.runOnce('catalog:rating'),
+      ]);
+
+      // Une seule passe a fetché (le 2e run est un no-op).
+      expect(postMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('le flag est relâché après le run (un run suivant repart)', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      postMock.mockReturnValue(of(muPage(1000, 100, 100)));
+
+      await service.runOnce('catalog:rating');
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 1 }),
+      );
+      await service.runOnce('catalog:rating');
+
+      expect(postMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('rythme réseau', () => {
+    it('attend delayMs (2000 ms) après chaque page ingérée', async () => {
+      stateRepo.findOneBy.mockResolvedValue(
+        makeState({ last_completed_page: 0, total_pages: 2 }),
+      );
+      postMock.mockImplementation((_url: string, payload: { page: number }) =>
+        of(muPage(payload.page * 1000, 100, 200)),
+      );
+
+      await service.runOnce('catalog:rating');
+
+      const delayCalls = sleepMock.mock.calls.filter((c) => c[0] === 2000);
+      expect(delayCalls).toHaveLength(2); // une pause par page
+    });
+  });
+
+  describe('handleNightlySync', () => {
+    it('est un no-op quand CATALOG_SYNC_ENABLED est résolu à false (NODE_ENV=test)', async () => {
+      await service.handleNightlySync();
+      expect(postMock).not.toHaveBeenCalled();
+      expect(sleepMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/mangas/catalog-sync.service.ts
+++ b/src/api/mangas/catalog-sync.service.ts
@@ -1,0 +1,379 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AxiosError } from 'axios';
+import { firstValueFrom } from 'rxjs';
+import { Repository } from 'typeorm';
+import {
+  CatalogSyncJobName,
+  CatalogSyncState,
+} from './catalog-sync-state.entity';
+import {
+  buildCatalogUpsertRows,
+  CatalogPage,
+  intFromConfig,
+  MuSearchBody,
+  MuSearchResult,
+} from './catalog-sync.mapper';
+import { MU_TRENDS_URL, NSFW_GENRES } from './constants';
+import { Manga } from './manga.entity';
+import { MangasService } from './mangas.service';
+
+/**
+ * Synchronisation nightly du catalogue MangaUpdates vers la table `manga`
+ * (design catalogue-recos, étape 2) : constitue un catalogue local (~5000
+ * titres par rating + top hebdo) pour que `CatalogCandidateService` puisse
+ * élargir les recommandations sans appel MU à chaud.
+ *
+ * Politique réseau (MU ≈ 60 req/min anonyme) : 1 requête /
+ * `CATALOG_SYNC_DELAY_MS` (2000 ms = 30 req/min = 50 % du plafond), cron
+ * 03:30 + jitter 0-15 min, backoff 5/10/20/40 s sur 429/5xx. Échec
+ * persistant → arrêt PROPRE : curseur persisté, statut `partial`,
+ * `consecutive_failures++` — jamais avalé.
+ *
+ * Anti-réentrance : flag `running` in-process (1 seul process API en prod).
+ * Si l'API passe multi-instance, remplacer par un `pg_advisory_lock`.
+ */
+@Injectable()
+export class CatalogSyncService {
+  private readonly logger = new Logger(CatalogSyncService.name);
+
+  /** perpage max accepté par MU (au-delà, coercion silencieuse). */
+  private static readonly PER_PAGE = 100;
+
+  /** Page max acceptée par MU (au-delà : 400 Bad Request). */
+  private static readonly MU_PAGE_HARD_CAP = 400;
+
+  /** Pages de la passe hebdo `week_pos` (dimanche). */
+  private static readonly WEEKLY_PAGES = 10;
+
+  /** Jitter max avant le run nightly (15 min). */
+  private static readonly JITTER_MAX_MS = 15 * 60 * 1000;
+
+  /** Backoff sur 429/5xx (4 tentatives après l'appel initial). */
+  private static readonly BACKOFF_DELAYS_MS = [5_000, 10_000, 20_000, 40_000];
+
+  private readonly enabled: boolean;
+  private readonly maxPages: number;
+  private readonly pagesPerRun: number;
+  private readonly delayMs: number;
+  private readonly hydrationBudget: number;
+
+  /** Anti-réentrance in-process (voir doc de classe). */
+  private running = false;
+
+  /** Warn une seule fois si le payload search ne contient pas les genres. */
+  private genresMissingWarned = false;
+
+  /** Injectable pour les tests (évite les vrais timers). */
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  constructor(
+    private readonly httpService: HttpService,
+    @InjectRepository(CatalogSyncState)
+    private readonly stateRepository: Repository<CatalogSyncState>,
+    @InjectRepository(Manga)
+    private readonly mangaRepository: Repository<Manga>,
+    private readonly mangasService: MangasService,
+    config: ConfigService,
+  ) {
+    const enabledRaw = config.get<string>('CATALOG_SYNC_ENABLED');
+    // Défaut : activé, sauf en environnement de test.
+    this.enabled =
+      enabledRaw !== undefined && enabledRaw !== ''
+        ? enabledRaw === 'true'
+        : config.get<string>('NODE_ENV') !== 'test';
+    this.maxPages = intFromConfig(config, 'CATALOG_SYNC_MAX_PAGES', 50);
+    this.pagesPerRun = intFromConfig(config, 'CATALOG_SYNC_PAGES_PER_RUN', 60);
+    this.delayMs = intFromConfig(config, 'CATALOG_SYNC_DELAY_MS', 2000);
+    this.hydrationBudget = intFromConfig(
+      config,
+      'CATALOG_SYNC_HYDRATION_BUDGET',
+      200,
+    );
+  }
+
+  /** Cron nightly 03:30 (heure serveur) + jitter aléatoire 0-15 min. */
+  @Cron('0 30 3 * * *')
+  async handleNightlySync(): Promise<void> {
+    if (!this.enabled) return;
+    const jitterMs = Math.floor(
+      Math.random() * CatalogSyncService.JITTER_MAX_MS,
+    );
+    this.logger.log(
+      `Sync catalogue nightly dans ${Math.round(jitterMs / 1000)} s (jitter)`,
+    );
+    await this.sleep(jitterMs);
+    await this.runOnce();
+  }
+
+  /**
+   * Point d'entrée testable. Sans argument : passe `rating`, puis passe
+   * hebdo `week_pos` le dimanche, puis hydratation des genres manquants.
+   * Avec `jobName` : ce job uniquement. No-op (warn) si un run est déjà en
+   * cours (anti-réentrance).
+   */
+  async runOnce(jobName?: CatalogSyncJobName): Promise<void> {
+    if (this.running) {
+      this.logger.warn(
+        'Sync catalogue déjà en cours — run ignoré (anti-réentrance)',
+      );
+      return;
+    }
+    this.running = true;
+    try {
+      const weekly: [CatalogSyncJobName, string, number] = [
+        'catalog:week_pos',
+        'week_pos',
+        CatalogSyncService.WEEKLY_PAGES,
+      ];
+      if (jobName === 'catalog:rating') {
+        await this.runCatalogPass('catalog:rating', 'rating', this.maxPages);
+      } else if (jobName === 'catalog:week_pos') {
+        await this.runCatalogPass(...weekly);
+      } else if (jobName === 'hydration') {
+        await this.hydrateMissingGenres();
+      } else {
+        await this.runCatalogPass('catalog:rating', 'rating', this.maxPages);
+        if (new Date().getDay() === 0) await this.runCatalogPass(...weekly);
+        await this.hydrateMissingGenres();
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /**
+   * Une passe de catalogue : reprend au curseur persisté, ingère au plus
+   * `CATALOG_SYNC_PAGES_PER_RUN` pages (curseur persisté page par page).
+   * Dernière page atteinte → curseur remis à 0, statut `completed`.
+   */
+  private async runCatalogPass(
+    jobName: CatalogSyncJobName,
+    orderby: string,
+    pagesCap: number,
+  ): Promise<void> {
+    const state = await this.getOrCreateState(jobName);
+    let page = state.last_completed_page;
+    let totalPages = state.total_pages;
+    let pagesFetched = 0;
+
+    while (pagesFetched < this.pagesPerRun) {
+      if (page >= this.effectiveLastPage(totalPages, pagesCap)) break;
+      const nextPage = page + 1;
+
+      let result: CatalogPage;
+      try {
+        result = await this.fetchPageWithBackoff(orderby, nextPage);
+      } catch (err) {
+        // Backoff épuisé ou erreur non-retryable : arrêt PROPRE.
+        state.last_completed_page = page;
+        state.total_pages = totalPages;
+        state.last_run_at = new Date();
+        state.last_run_status = 'partial';
+        state.consecutive_failures += 1;
+        await this.stateRepository.save(state);
+        this.logger.warn(
+          `[${jobName}] arrêt partiel sur la page ${nextPage} : ${
+            (err as Error)?.message ?? err
+          } — reprise à la page ${page + 1} au prochain run`,
+        );
+        return;
+      }
+
+      await this.upsertPage(result.records);
+      pagesFetched += 1;
+      page = nextPage;
+      totalPages = Math.max(
+        1,
+        Math.ceil(result.totalHits / CatalogSyncService.PER_PAGE),
+      );
+      state.last_completed_page = page;
+      state.total_pages = totalPages;
+      await this.stateRepository.save(state);
+
+      // 1 requête / delayMs (30 req/min à 2000 ms = 50 % du plafond MU).
+      await this.sleep(this.delayMs);
+    }
+
+    const done = page >= this.effectiveLastPage(totalPages, pagesCap);
+    state.last_completed_page = done ? 0 : page;
+    state.total_pages = totalPages;
+    state.last_run_at = new Date();
+    state.last_run_status = done ? 'completed' : 'partial';
+    if (done) state.consecutive_failures = 0;
+    await this.stateRepository.save(state);
+    this.logger.log(
+      `[${jobName}] ${pagesFetched} page(s) ingérée(s) — ${
+        done
+          ? 'passe complétée (curseur remis à 0)'
+          : `budget épuisé, reprise à la page ${page + 1}`
+      }`,
+    );
+  }
+
+  /** Dernière page de la passe : min(total_pages, cap job, cap MU 400). */
+  private effectiveLastPage(
+    totalPages: number | null,
+    pagesCap: number,
+  ): number {
+    const cap = Math.min(pagesCap, CatalogSyncService.MU_PAGE_HARD_CAP);
+    return totalPages === null ? cap : Math.min(totalPages, cap);
+  }
+
+  /** POST MU /series/search — une page du catalogue (perpage 100). */
+  async fetchSearchPage(orderby: string, page: number): Promise<CatalogPage> {
+    const payload = {
+      orderby,
+      perpage: CatalogSyncService.PER_PAGE,
+      page,
+      exclude_genre: NSFW_GENRES,
+    };
+    const { data } = await firstValueFrom(
+      this.httpService.post<MuSearchBody>(MU_TRENDS_URL, payload),
+    );
+    const records = data?.results ?? [];
+    const totalHits = Number(data?.total_hits ?? records.length) || 0;
+    return { records, totalHits };
+  }
+
+  /**
+   * fetchSearchPage avec backoff 5/10/20/40 s sur 429/5xx. Toute autre
+   * erreur est rethrow immédiatement — le caller fait l'arrêt propre.
+   */
+  private async fetchPageWithBackoff(
+    orderby: string,
+    page: number,
+  ): Promise<CatalogPage> {
+    let lastError: unknown;
+    const retries = CatalogSyncService.BACKOFF_DELAYS_MS;
+    for (let attempt = 0; attempt <= retries.length; attempt++) {
+      if (attempt > 0) {
+        const delay = retries[attempt - 1];
+        this.logger.warn(
+          `MU ${orderby} page ${page} : retry ${attempt}/${retries.length} dans ${delay} ms`,
+        );
+        await this.sleep(delay);
+      }
+      try {
+        return await this.fetchSearchPage(orderby, page);
+      } catch (err) {
+        lastError = err;
+        const status = (err as AxiosError)?.response?.status;
+        const retryable =
+          status === 429 || (typeof status === 'number' && status >= 500);
+        if (!retryable) throw err;
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /**
+   * Upsert d'une page en DEUX lots pour ne JAMAIS écraser des genres
+   * existants par null : le lot « sans genres » omet la colonne `genres`
+   * du `orUpdate`. `total_chapters` / `completed` / `associated` ne sont
+   * jamais listés → intouchés (préserve GREATEST et les données détail).
+   */
+  private async upsertPage(records: MuSearchResult[]): Promise<void> {
+    const { withGenres, withoutGenres } = buildCatalogUpsertRows(records);
+
+    if (
+      records.length > 0 &&
+      withGenres.length === 0 &&
+      !this.genresMissingWarned
+    ) {
+      this.genresMissingWarned = true;
+      this.logger.warn(
+        'Payload search MU sans `record.genres` — hydratation différée via hydrateMissingGenres/getMangaDetails',
+      );
+    }
+
+    const baseColumns = [
+      'title',
+      'year',
+      'rating',
+      'small_cover_url',
+      'medium_cover_url',
+    ];
+    if (withGenres.length > 0) {
+      await this.mangaRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Manga)
+        .values(withGenres)
+        .orUpdate([...baseColumns, 'genres'], ['mu_id'])
+        .execute();
+    }
+    if (withoutGenres.length > 0) {
+      await this.mangaRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Manga)
+        .values(withoutGenres)
+        .orUpdate(baseColumns, ['mu_id'])
+        .execute();
+    }
+  }
+
+  /**
+   * Hydrate les mangas sans genres (catalogue ingéré sans `record.genres`
+   * + stubs de `saveRecommendations`) via `getMangaDetails` (UPDATE
+   * complet), les mieux notés d'abord, au rythme d'1 appel / delayMs.
+   * @returns nombre de mangas hydratés avec succès.
+   */
+  async hydrateMissingGenres(
+    budget: number = this.hydrationBudget,
+  ): Promise<number> {
+    const stubs = await this.mangaRepository
+      .createQueryBuilder('m')
+      .where('m.genres IS NULL')
+      .orderBy('m.rating', 'DESC', 'NULLS LAST')
+      .limit(budget)
+      .getMany();
+    if (stubs.length === 0) return 0;
+
+    let hydrated = 0;
+    for (const manga of stubs) {
+      try {
+        await this.mangasService.getMangaDetails(Number(manga.mu_id));
+        hydrated += 1;
+      } catch (err) {
+        this.logger.warn(
+          `Hydratation genres mu_id=${manga.mu_id} en échec : ${
+            (err as Error)?.message ?? err
+          }`,
+        );
+      }
+      await this.sleep(this.delayMs);
+    }
+
+    const state = await this.getOrCreateState('hydration');
+    state.last_run_at = new Date();
+    state.last_run_status = 'completed';
+    await this.stateRepository.save(state);
+    this.logger.log(
+      `Hydratation genres : ${hydrated}/${stubs.length} manga(s) complétés`,
+    );
+    return hydrated;
+  }
+
+  private async getOrCreateState(
+    jobName: CatalogSyncJobName,
+  ): Promise<CatalogSyncState> {
+    const existing = await this.stateRepository.findOneBy({
+      job_name: jobName,
+    });
+    if (existing) return existing;
+    return this.stateRepository.create({
+      job_name: jobName,
+      last_completed_page: 0,
+      total_pages: null,
+      last_run_at: null,
+      last_run_status: null,
+      consecutive_failures: 0,
+    });
+  }
+}

--- a/src/api/mangas/catalog-sync.service.ts
+++ b/src/api/mangas/catalog-sync.service.ts
@@ -11,7 +11,7 @@ import {
   CatalogSyncState,
 } from './catalog-sync-state.entity';
 import {
-  buildCatalogUpsertRows,
+  buildCatalogUpsertBatches,
   CatalogPage,
   intFromConfig,
   MuSearchBody,
@@ -165,35 +165,26 @@ export class CatalogSyncService {
       if (page >= this.effectiveLastPage(totalPages, pagesCap)) break;
       const nextPage = page + 1;
 
-      let result: CatalogPage;
       try {
-        result = await this.fetchPageWithBackoff(orderby, nextPage);
-      } catch (err) {
-        // Backoff épuisé ou erreur non-retryable : arrêt PROPRE.
+        // fetch + upsert + persistance du curseur dans le MÊME try : une
+        // erreur DB ne doit pas sortir sans mettre à jour le statut.
+        const result = await this.fetchPageWithBackoff(orderby, nextPage);
+        await this.upsertPage(result.records);
+        pagesFetched += 1;
+        page = nextPage;
+        totalPages = Math.max(
+          1,
+          Math.ceil(result.totalHits / CatalogSyncService.PER_PAGE),
+        );
         state.last_completed_page = page;
         state.total_pages = totalPages;
-        state.last_run_at = new Date();
-        state.last_run_status = 'partial';
-        state.consecutive_failures += 1;
         await this.stateRepository.save(state);
-        this.logger.warn(
-          `[${jobName}] arrêt partiel sur la page ${nextPage} : ${
-            (err as Error)?.message ?? err
-          } — reprise à la page ${page + 1} au prochain run`,
-        );
+      } catch (err) {
+        // Backoff épuisé, erreur non-retryable, OU erreur DB : arrêt PROPRE
+        // (curseur conservé, upsert idempotent → reprise sans doublon).
+        await this.persistPartial(state, page, totalPages, jobName, nextPage, err);
         return;
       }
-
-      await this.upsertPage(result.records);
-      pagesFetched += 1;
-      page = nextPage;
-      totalPages = Math.max(
-        1,
-        Math.ceil(result.totalHits / CatalogSyncService.PER_PAGE),
-      );
-      state.last_completed_page = page;
-      state.total_pages = totalPages;
-      await this.stateRepository.save(state);
 
       // 1 requête / delayMs (30 req/min à 2000 ms = 50 % du plafond MU).
       await this.sleep(this.delayMs);
@@ -205,7 +196,16 @@ export class CatalogSyncService {
     state.last_run_at = new Date();
     state.last_run_status = done ? 'completed' : 'partial';
     if (done) state.consecutive_failures = 0;
-    await this.stateRepository.save(state);
+    try {
+      await this.stateRepository.save(state);
+    } catch (err) {
+      this.logger.error(
+        `[${jobName}] échec de persistance du statut final : ${
+          (err as Error)?.message ?? err
+        }`,
+      );
+      return;
+    }
     this.logger.log(
       `[${jobName}] ${pagesFetched} page(s) ingérée(s) — ${
         done
@@ -213,6 +213,42 @@ export class CatalogSyncService {
           : `budget épuisé, reprise à la page ${page + 1}`
       }`,
     );
+  }
+
+  /**
+   * Persiste un arrêt PARTIEL d'une passe (échec réseau ou DB) : curseur
+   * conservé, statut `partial`, `consecutive_failures++`, log warn. La
+   * persistance du statut est best-effort — si la DB est la cause de l'échec,
+   * on ne peut que logger. L'exception n'est PAS propagée, pour ne pas sauter
+   * les passes suivantes du run (rating → week_pos → hydration).
+   */
+  private async persistPartial(
+    state: CatalogSyncState,
+    page: number,
+    totalPages: number | null,
+    jobName: CatalogSyncJobName,
+    failedPage: number,
+    err: unknown,
+  ): Promise<void> {
+    state.last_completed_page = page;
+    state.total_pages = totalPages;
+    state.last_run_at = new Date();
+    state.last_run_status = 'partial';
+    state.consecutive_failures += 1;
+    this.logger.warn(
+      `[${jobName}] arrêt partiel sur la page ${failedPage} : ${
+        (err as Error)?.message ?? err
+      } — reprise à la page ${page + 1} au prochain run`,
+    );
+    try {
+      await this.stateRepository.save(state);
+    } catch (saveErr) {
+      this.logger.error(
+        `[${jobName}] échec de persistance du statut partiel : ${
+          (saveErr as Error)?.message ?? saveErr
+        }`,
+      );
+    }
   }
 
   /** Dernière page de la passe : min(total_pages, cap job, cap MU 400). */
@@ -272,48 +308,32 @@ export class CatalogSyncService {
   }
 
   /**
-   * Upsert d'une page en DEUX lots pour ne JAMAIS écraser des genres
-   * existants par null : le lot « sans genres » omet la colonne `genres`
-   * du `orUpdate`. `total_chapters` / `completed` / `associated` ne sont
-   * jamais listés → intouchés (préserve GREATEST et les données détail).
+   * Upsert d'une page en lots regroupés par colonnes NON-NULL : chaque lot ne
+   * liste dans son `orUpdate` que les colonnes réellement renseignées, donc
+   * une colonne absente du payload MU (rating/year/covers/genres) n'écrase
+   * JAMAIS la valeur existante par null (préserve l'hydratation détail).
+   * `total_chapters` / `completed` / `associated` ne sont jamais listés →
+   * intouchés (préserve GREATEST et les données détail).
    */
   private async upsertPage(records: MuSearchResult[]): Promise<void> {
-    const { withGenres, withoutGenres } = buildCatalogUpsertRows(records);
+    const batches = buildCatalogUpsertBatches(records);
 
-    if (
-      records.length > 0 &&
-      withGenres.length === 0 &&
-      !this.genresMissingWarned
-    ) {
+    const hasAnyGenres = batches.some((b) => b.overwrite.includes('genres'));
+    if (records.length > 0 && !hasAnyGenres && !this.genresMissingWarned) {
       this.genresMissingWarned = true;
       this.logger.warn(
         'Payload search MU sans `record.genres` — hydratation différée via hydrateMissingGenres/getMangaDetails',
       );
     }
 
-    const baseColumns = [
-      'title',
-      'year',
-      'rating',
-      'small_cover_url',
-      'medium_cover_url',
-    ];
-    if (withGenres.length > 0) {
+    for (const batch of batches) {
+      if (batch.rows.length === 0) continue;
       await this.mangaRepository
         .createQueryBuilder()
         .insert()
         .into(Manga)
-        .values(withGenres)
-        .orUpdate([...baseColumns, 'genres'], ['mu_id'])
-        .execute();
-    }
-    if (withoutGenres.length > 0) {
-      await this.mangaRepository
-        .createQueryBuilder()
-        .insert()
-        .into(Manga)
-        .values(withoutGenres)
-        .orUpdate(baseColumns, ['mu_id'])
+        .values(batch.rows)
+        .orUpdate(batch.overwrite, ['mu_id'])
         .execute();
     }
   }

--- a/src/api/mangas/dto/manga-details.dto.ts
+++ b/src/api/mangas/dto/manga-details.dto.ts
@@ -147,6 +147,17 @@ export class MangaDetailsDto {
   @IsNumber()
   aggregated_rating?: number;
 
+  @ApiPropertyOptional({
+    description:
+      'Description traduite dans la langue du header Accept-Language. ' +
+      'Absent si la langue est en/absente/non supportée ou si la ' +
+      'traduction a échoué — `description` reste TOUJOURS l’original ' +
+      'anglais (champ additif, non-breaking).',
+  })
+  @IsOptional()
+  @IsString()
+  translated_description?: string;
+
   private static parseLatestChapter(status: string, fallback: number): number {
     if (!status) return fallback;
     const match = status.match(/(\d+)\s*Chapters/);

--- a/src/api/mangas/dto/manga-quick-view.dto.ts
+++ b/src/api/mangas/dto/manga-quick-view.dto.ts
@@ -86,6 +86,14 @@ export class MangaQuickViewDto {
   })
   aggregatedRating?: number;
 
+  @IsNumber()
+  @IsOptional()
+  @ApiPropertyOptional({
+    description:
+      "Total de chapitres signalé par l'utilisateur (« ce manga a plus de chapitres »). Présent uniquement si le report dépasse encore le total officiel ; totalChapters reflète déjà ce total effectif.",
+  })
+  userReportedTotalChapters?: number;
+
   static fromMu(data: any) {
     const dto = new MangaQuickViewDto();
     dto.muId = data['record']['series_id'];
@@ -101,7 +109,13 @@ export class MangaQuickViewDto {
     return dto;
   }
 
-  static fromLibrary(userManga: UserManga) {
+  /**
+   * @param userReportedTotal Total « plus de chapitres » signalé par l'user
+   *   (Chantier A). `totalChapters` expose le total EFFECTIF
+   *   (max(officiel, report)) pour que le client débloque l'UI au-delà du
+   *   total officiel sans logique supplémentaire.
+   */
+  static fromLibrary(userManga: UserManga, userReportedTotal?: number) {
     const dto = new MangaQuickViewDto();
     dto.muId = parseInt(userManga.manga.mu_id);
     dto.title = userManga.manga.title;
@@ -112,7 +126,16 @@ export class MangaQuickViewDto {
     dto.largeCoverUrl = userManga.manga.medium_cover_url;
     dto.rating = userManga.manga.rating;
     dto.readChapters = userManga.user_read_chapters;
-    dto.totalChapters = userManga.manga.total_chapters;
+    dto.totalChapters = Math.max(
+      userManga.manga.total_chapters ?? 0,
+      userReportedTotal ?? 0,
+    );
+    if (
+      userReportedTotal !== undefined &&
+      userReportedTotal > (userManga.manga.total_chapters ?? 0)
+    ) {
+      dto.userReportedTotalChapters = userReportedTotal;
+    }
     dto.readingStatus = userManga.readingStatus;
     dto.associated = userManga.manga.associated ?? [];
     dto.customLink = userManga.custom_link ?? undefined;

--- a/src/api/mangas/exceptions/mu-rate-limit.exception.ts
+++ b/src/api/mangas/exceptions/mu-rate-limit.exception.ts
@@ -1,0 +1,18 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * MangaUpdates a répondu 429 (rate-limit).
+ *
+ * Levée par `MangasService.fetchAndCacheRecommendations` pour que les boucles
+ * de fetch amont (RecommendationService.fetchAndScoreBlocking) puissent
+ * distinguer un throttling MU (→ pause 5 s avant le batch suivant) d'un échec
+ * quelconque (→ skip silencieux).
+ */
+export class MuRateLimitException extends HttpException {
+  constructor(muId: number) {
+    super(
+      `MangaUpdates rate limit (429) lors du fetch des recommandations du manga ${muId}`,
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+}

--- a/src/api/mangas/genre.utils.ts
+++ b/src/api/mangas/genre.utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Forme brute d'un genre côté MangaUpdates : selon l'endpoint, MU renvoie
+ * `[{genre: "Action"}]` (search/détail) ou parfois directement `["Action"]`.
+ */
+type RawGenre = string | { genre?: string; name?: string } | null | undefined;
+
+/**
+ * Normalise la liste de genres MU vers un `string[]` homogène pour stockage
+ * en BDD et requêtage uniforme (`genres::jsonb ?| ...`).
+ *
+ * Sémantique (héritée de `Manga.fromMU` et `MangasService.getMangaDetails`,
+ * dédupliquée ici) :
+ * - `null`/`undefined` → `[]` (traité comme liste vide, pas comme inconnu) ;
+ * - valeur non-array → `null` ;
+ * - array → entrées mappées (string directe ou `.genre`/`.name`), les vides
+ *   filtrées.
+ */
+export function normalizeGenres(rawGenres: unknown): string[] | null {
+  const source = rawGenres ?? [];
+  if (!Array.isArray(source)) return null;
+  return (source as RawGenre[])
+    .map((g) => (typeof g === 'string' ? g : g?.genre ?? g?.name ?? ''))
+    .filter((g): g is string => typeof g === 'string' && g.length > 0);
+}

--- a/src/api/mangas/manga-translation.entity.ts
+++ b/src/api/mangas/manga-translation.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Column,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Cache serveur des descriptions traduites (Chantier A — traduction des
+ * descriptions côté serveur).
+ *
+ * Une ligne = "la description du manga `mu_id` traduite en `language`".
+ * La décision de re-traduction est portée par `source_hash` (sha256 de la
+ * description MU du jour) : la source n'est jamais persistée, elle est
+ * refetchée live par `getMangaDetails` — tout changement de description
+ * upstream invalide donc naturellement la traduction au hit suivant.
+ *
+ * Nom singulier assumé, cohérent avec le schéma existant (`manga`,
+ * `manga_recommendation`, `user_manga`).
+ */
+@Entity('manga_translation')
+@Index(['mu_id', 'language'], { unique: true })
+export class MangaTranslation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  /** mu_id du manga (même convention bigint/string que manga_recommendation) */
+  @Column({ type: 'bigint' })
+  mu_id: string;
+
+  /** Langue cible (code primaire 2 lettres : fr, de, es, pt, ja, ko) */
+  @Column({ type: 'varchar', length: 5 })
+  language: string;
+
+  /** sha256 hex de la description source (anglaise) au moment de la traduction */
+  @Column({ type: 'varchar', length: 64 })
+  source_hash: string;
+
+  /** Description traduite dans `language` */
+  @Column({ type: 'text' })
+  translated_description: string;
+
+  /** Observabilité/debug uniquement — la re-traduction est pilotée par source_hash */
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/api/mangas/manga.entity.ts
+++ b/src/api/mangas/manga.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { MangaDetailsDto } from './dto/manga-details.dto';
 import { UserManga } from './user-manga.entity';
+import { normalizeGenres } from './genre.utils';
 
 @Entity()
 export class Manga {
@@ -99,15 +100,8 @@ export class Manga {
     manga.completed = mangaDetailsDto.completed;
     manga.associated = mangaDetailsDto.associated ?? [];
     // genres : MU les renvoie sous forme `[{genre: "Action"}, {genre: "Romance"}]`
-    // ou parfois directement `["Action", ...]`. On normalise.
-    const rawGenres = (mangaDetailsDto as any).genres ?? [];
-    manga.genres = Array.isArray(rawGenres)
-      ? rawGenres
-          .map((g: any) =>
-            typeof g === 'string' ? g : g?.genre ?? g?.name ?? '',
-          )
-          .filter((g: string) => g.length > 0)
-      : null;
+    // ou parfois directement `["Action", ...]`. Normalisation partagée.
+    manga.genres = normalizeGenres((mangaDetailsDto as any).genres);
     return manga;
   }
 }

--- a/src/api/mangas/mangas.controller.spec.ts
+++ b/src/api/mangas/mangas.controller.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MangasController } from './mangas.controller';
+import { MangasService } from './mangas.service';
+import { LibraryService } from '@/api/library/library.service';
+import { DescriptionTranslationService } from './translation/description-translation.service';
+import { MangaDetailsDto } from './dto/manga-details.dto';
+
+describe('MangasController — mangaDetails / translated_description', () => {
+  let controller: MangasController;
+  let mangasService: {
+    getMangaDetails: jest.Mock;
+    getCommunityRatings: jest.Mock;
+  };
+  let libraryService: { getUserManga: jest.Mock };
+  let translationService: {
+    parsePrimaryLang: jest.Mock;
+    getTranslatedDescription: jest.Mock;
+  };
+
+  const baseDetails = () => {
+    const dto = new MangaDetailsDto();
+    dto.muId = 42;
+    dto.title = 'Test Manga';
+    dto.description = 'Original English description.';
+    dto.rating = 8.2;
+    return dto;
+  };
+
+  beforeEach(async () => {
+    mangasService = {
+      getMangaDetails: jest.fn().mockResolvedValue(baseDetails()),
+      getCommunityRatings: jest.fn().mockResolvedValue(new Map()),
+    };
+    libraryService = { getUserManga: jest.fn().mockResolvedValue(null) };
+    translationService = {
+      parsePrimaryLang: jest.fn().mockReturnValue(null),
+      getTranslatedDescription: jest.fn().mockResolvedValue(null),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MangasController],
+      providers: [
+        { provide: MangasService, useValue: mangasService },
+        { provide: LibraryService, useValue: libraryService },
+        {
+          provide: DescriptionTranslationService,
+          useValue: translationService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<MangasController>(MangasController);
+  });
+
+  it('should return translated_description when Accept-Language requests a supported lang', async () => {
+    translationService.parsePrimaryLang.mockReturnValue('fr');
+    translationService.getTranslatedDescription.mockResolvedValue(
+      'Description originale traduite.',
+    );
+
+    const result = await controller.mangaDetails(
+      42,
+      { id: 7 },
+      'fr-FR,fr;q=0.9',
+    );
+
+    expect(translationService.parsePrimaryLang).toHaveBeenCalledWith(
+      'fr-FR,fr;q=0.9',
+    );
+    expect(translationService.getTranslatedDescription).toHaveBeenCalledWith(
+      42,
+      'Original English description.',
+      'fr',
+    );
+    expect(result.translated_description).toBe(
+      'Description originale traduite.',
+    );
+    // La description originale reste TOUJOURS renvoyée telle quelle.
+    expect(result.description).toBe('Original English description.');
+  });
+
+  it('should not return translated_description without Accept-Language header', async () => {
+    const result = await controller.mangaDetails(42, { id: 7 }, undefined);
+
+    expect(translationService.parsePrimaryLang).toHaveBeenCalledWith(undefined);
+    expect(translationService.getTranslatedDescription).toHaveBeenCalledWith(
+      42,
+      'Original English description.',
+      null,
+    );
+    expect(result.translated_description).toBeUndefined();
+    expect(result.description).toBe('Original English description.');
+  });
+});

--- a/src/api/mangas/mangas.controller.ts
+++ b/src/api/mangas/mangas.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Headers,
   Param,
   ParseIntPipe,
   Post,
@@ -23,6 +24,7 @@ import { SearchMangaDto } from './dto/search-manga.dto';
 import { SearchMangaResponseDto } from './dto/search-manga-response.dto';
 import { UserDecorator } from '@/shared/Decorator/user.decorator';
 import { LibraryService } from '@/api/library/library.service';
+import { DescriptionTranslationService } from './translation/description-translation.service';
 
 @ApiTags('Mangas')
 @ApiBearerAuth()
@@ -31,6 +33,7 @@ export class MangasController {
   constructor(
     private readonly mangasService: MangasService,
     private readonly libraryService: LibraryService,
+    private readonly descriptionTranslationService: DescriptionTranslationService,
   ) {}
 
   @ApiOperation({
@@ -135,8 +138,15 @@ export class MangasController {
   async mangaDetails(
     @Param('id', ParseIntPipe) id: number,
     @UserDecorator() user: any,
+    @Headers('accept-language') acceptLanguage?: string,
   ): Promise<MangaDetailsDto> {
     const mangaDetails = await this.mangasService.getMangaDetails(id);
+    const translated =
+      await this.descriptionTranslationService.getTranslatedDescription(
+        id,
+        mangaDetails.description,
+        this.descriptionTranslationService.parsePrimaryLang(acceptLanguage),
+      );
     let customLink: string | undefined = undefined;
     let inLibrary = false;
     let readChaptersCount: number | undefined = undefined;
@@ -171,6 +181,7 @@ export class MangasController {
       community_rating: c?.communityRating ?? undefined,
       community_rating_count: c?.communityRatingCount ?? 0,
       aggregated_rating: c?.aggregatedRating ?? undefined,
+      translated_description: translated ?? undefined,
     };
   }
 

--- a/src/api/mangas/mangas.module.ts
+++ b/src/api/mangas/mangas.module.ts
@@ -11,18 +11,39 @@ import User from 'src/api/user/user.entity';
 import { UserService } from 'src/api/user/user.service';
 import { LibraryModule } from '../library/library.module';
 import { LibraryService } from '../library/library.service';
+import { ChapterLogService } from '../library/chapter-log.service';
+import { ChapterReportService } from '../library/chapter-report.service';
+import { UserMangaChapterLog } from '../library/user-manga-chapter-log.entity';
+import { MangaChapterReport } from '../library/manga-chapter-report.entity';
 import { UpdateMangaService } from './update-manga.service';
 import { MangaSyncService } from './sync-manga.service';
+import { CatalogSyncService } from './catalog-sync.service';
+import { CatalogSyncState } from './catalog-sync-state.entity';
 import { CoverProxyService } from './cover-proxy.service';
 import { RecoCacheModule } from '../recommendations/reco-cache.module';
+import { MangaTranslation } from './manga-translation.entity';
+import { DescriptionTranslationService } from './translation/description-translation.service';
+import { DeeplProvider } from './translation/deepl.provider';
+import { GtxProvider } from './translation/gtx.provider';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Manga, MangaRecommendation, User, UserManga]),
+    TypeOrmModule.forFeature([
+      Manga,
+      MangaRecommendation,
+      MangaTranslation,
+      CatalogSyncState,
+      User,
+      UserManga,
+      UserMangaChapterLog,
+      MangaChapterReport,
+    ]),
     forwardRef(() => LibraryModule),
     // LibraryService est re-déclaré dans les providers ci-dessous → son
     // injection de RecoCacheService doit être résolue DANS ce contexte
-    // (hotfix-v0-10-1 US-4). Module autonome, pas de cycle.
+    // (hotfix-v0-10-1 US-4). Module autonome, pas de cycle. Idem pour
+    // ChapterLogService / ChapterReportService (chantiers A & B) et leurs
+    // entités dans le forFeature ci-dessus.
     RecoCacheModule,
   ],
   controllers: [MangasController, MangaCoversController],
@@ -31,9 +52,15 @@ import { RecoCacheModule } from '../recommendations/reco-cache.module';
     HelperService,
     UserService,
     LibraryService,
+    ChapterLogService,
+    ChapterReportService,
     UpdateMangaService,
     MangaSyncService,
+    CatalogSyncService,
     CoverProxyService,
+    DescriptionTranslationService,
+    DeeplProvider,
+    GtxProvider,
   ],
   exports: [HelperService, UpdateMangaService, MangaSyncService, MangasService],
 })

--- a/src/api/mangas/mangas.service.spec.ts
+++ b/src/api/mangas/mangas.service.spec.ts
@@ -8,6 +8,7 @@ import { Manga } from './manga.entity';
 import { MangaRecommendation } from './manga-recommendation.entity';
 import { UserManga } from './user-manga.entity';
 import { MU_TRENDS_URL, NSFW_GENRES } from './constants';
+import { MuRateLimitException } from './exceptions/mu-rate-limit.exception';
 
 const mockRepo = () => ({
   find: jest.fn(),
@@ -52,6 +53,28 @@ describe('MangasService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getRecommendationsForManga — 429 MU gracieux', () => {
+    it('retombe sur [] quand fetchAndCacheRecommendations lève MuRateLimitException (pas de 429 client)', async () => {
+      jest.spyOn(service, 'getCachedRecommendations').mockResolvedValue([]);
+      jest
+        .spyOn(service, 'fetchAndCacheRecommendations')
+        .mockRejectedValue(new MuRateLimitException(1));
+
+      await expect(service.getRecommendationsForManga(1)).resolves.toEqual([]);
+    });
+
+    it('propage les autres erreurs (le 429 est le SEUL cas avalé ici)', async () => {
+      jest.spyOn(service, 'getCachedRecommendations').mockResolvedValue([]);
+      jest
+        .spyOn(service, 'fetchAndCacheRecommendations')
+        .mockRejectedValue(new Error('boom'));
+
+      await expect(service.getRecommendationsForManga(1)).rejects.toThrow(
+        'boom',
+      );
+    });
   });
 });
 

--- a/src/api/mangas/mangas.service.ts
+++ b/src/api/mangas/mangas.service.ts
@@ -10,6 +10,8 @@ import { MangaQuickViewDto } from './dto/manga-quick-view.dto';
 import { catchError, firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
 import { MU_DETAIL_URL, MU_TRENDS_URL, NSFW_GENRES } from './constants';
+import { normalizeGenres } from './genre.utils';
+import { MuRateLimitException } from './exceptions/mu-rate-limit.exception';
 import { HelperService } from './helper.service';
 import { MangaDetailsDto } from './dto/manga-details.dto';
 import { SearchMangaResponseDto } from './dto/search-manga-response.dto';
@@ -138,30 +140,30 @@ export class MangasService {
     const details = MangaDetailsDto.fromMU(data);
 
     // Normalise les genres MU (forme `[{genre: "Action"}]` ou `["Action"]`)
-    // avant stockage en BDD pour requêtage uniforme.
-    const rawGenres = (details as any).genres ?? [];
-    const normalizedGenres = Array.isArray(rawGenres)
-      ? rawGenres
-          .map((g: any) =>
-            typeof g === 'string' ? g : g?.genre ?? g?.name ?? '',
-          )
-          .filter((g: string) => g.length > 0)
-      : null;
+    // avant stockage en BDD pour requêtage uniforme (helper partagé).
+    const normalizedGenres = normalizeGenres((details as any).genres);
 
-    await this.mangaRepository.update(
-      { mu_id: muId.toString() },
-      {
+    // A-5 : GREATEST inconditionnel sur total_chapters — un refresh MU ne
+    // fait JAMAIS régresser le total (regex status MU peu fiable, un user à
+    // 90 chapitres lus prouve total ≥ 90 — cf. decisions.md). Les autres
+    // champs restent écrasés (overwrite).
+    await this.mangaRepository
+      .createQueryBuilder()
+      .update(Manga)
+      .set({
         title: details.title,
         year: details.year,
         small_cover_url: details.smallCoverUrl,
         medium_cover_url: details.mediumCoverUrl,
         rating: details.rating,
-        total_chapters: details.totalChapters,
+        total_chapters: () => 'GREATEST(total_chapters, :newTotal)',
         completed: details.completed,
         associated: details.associated,
         genres: normalizedGenres,
-      },
-    );
+      })
+      .setParameter('newTotal', Number(details.totalChapters) || 0)
+      .where('mu_id = :muId', { muId: muId.toString() })
+      .execute();
 
     // Sauvegarde des recommandations en arrière-plan (fire-and-forget)
     if (details.muRecommendations?.length) {
@@ -325,8 +327,9 @@ export class MangasService {
 
   /**
    * Récupère les recommandations depuis MangaUpdates pour un muId,
-   * les sauvegarde et les retourne.
-   * Utilisé quand le cache est absent ou périmé.
+   * les sauvegarde et les retourne. Utilisé quand le cache est absent.
+   * @throws {MuRateLimitException} sur 429 MU (le caller doit temporiser) ;
+   *   tout autre échec est avalé (`[]`) comme avant.
    */
   async fetchAndCacheRecommendations(
     muId: number,
@@ -371,7 +374,10 @@ export class MangasService {
         await this.saveRecommendations(muId, recos);
       }
       return this.getCachedRecommendations(muId);
-    } catch {
+    } catch (err) {
+      if ((err as AxiosError)?.response?.status === 429) {
+        throw new MuRateLimitException(muId);
+      }
       return [];
     }
   }

--- a/src/api/mangas/mangas.service.ts
+++ b/src/api/mangas/mangas.service.ts
@@ -390,7 +390,22 @@ export class MangasService {
   ): Promise<MangaRecommendation[]> {
     const cached = await this.getCachedRecommendations(muId);
     if (cached.length === 0) {
-      return this.fetchAndCacheRecommendations(muId);
+      try {
+        return await this.fetchAndCacheRecommendations(muId);
+      } catch (err) {
+        // 429 MU : NE PAS propager au client. `GET /mangas/:id/recommendations`
+        // doit renvoyer une liste (vide ici — les recos communautaires sont
+        // ajoutées par `getRecommendationsAsQuickView`), pas un 429. Le rethrow
+        // typé `MuRateLimitException` ne sert QUE les boucles de fetch du
+        // `RecommendationService` (qui, elles, temporisent 5 s puis reprennent).
+        if (err instanceof MuRateLimitException) {
+          this.logger.warn(
+            `Recos manga ${muId} indisponibles (MU 429) — dégradation gracieuse (liste communautaire seule)`,
+          );
+          return [];
+        }
+        throw err;
+      }
     }
     // Rafraîchir si le cache est plus vieux que 7 jours (en background)
     const oldest = cached.reduce((prev, cur) =>

--- a/src/api/mangas/translation/deepl.provider.ts
+++ b/src/api/mangas/translation/deepl.provider.ts
@@ -1,0 +1,82 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import { TranslationProvider } from './translation-provider.interface';
+
+export const DEEPL_API_URL = 'https://api-free.deepl.com/v2/translate';
+
+/**
+ * Mapping code primaire 2 lettres → target_lang DeepL.
+ * `pt` est mappé explicitement (DeepL exige PT-PT ou PT-BR, le `PT` nu est
+ * déprécié).
+ */
+const DEEPL_TARGET_LANG: Record<string, string> = {
+  fr: 'FR',
+  de: 'DE',
+  es: 'ES',
+  pt: 'PT-PT',
+  ja: 'JA',
+  ko: 'KO',
+};
+
+interface DeeplResponse {
+  translations?: { text?: string }[];
+}
+
+/**
+ * Provider DeepL API Free — primaire quand `DEEPL_API_KEY` est défini.
+ * Sans clé, le provider est inactif (`translate` → null immédiat) et le
+ * `DescriptionTranslationService` bascule sur gtx.
+ */
+@Injectable()
+export class DeeplProvider implements TranslationProvider {
+  readonly name = 'deepl';
+
+  private readonly logger = new Logger(DeeplProvider.name);
+  private readonly apiKey: string | undefined;
+
+  constructor(
+    private readonly httpService: HttpService,
+    configService: ConfigService,
+  ) {
+    this.apiKey = configService.get<string>('DEEPL_API_KEY');
+  }
+
+  /** Actif uniquement si une clé DeepL est configurée */
+  isEnabled(): boolean {
+    return typeof this.apiKey === 'string' && this.apiKey.trim().length > 0;
+  }
+
+  async translate(text: string, targetLang: string): Promise<string | null> {
+    if (!this.isEnabled()) return null;
+
+    const target = DEEPL_TARGET_LANG[targetLang];
+    if (!target) return null;
+
+    try {
+      const { data } = await firstValueFrom(
+        this.httpService.post<DeeplResponse>(
+          DEEPL_API_URL,
+          { text: [text], source_lang: 'EN', target_lang: target },
+          {
+            headers: { Authorization: `DeepL-Auth-Key ${this.apiKey}` },
+          },
+        ),
+      );
+      const translated = data?.translations?.[0]?.text;
+      return typeof translated === 'string' && translated.length > 0
+        ? translated
+        : null;
+    } catch (err) {
+      // 456 = quota mensuel DeepL épuisé, 429 = rate limit — dans tous les
+      // cas on log et on laisse la cascade basculer sur gtx.
+      this.logger.warn(
+        `DeepL translate vers ${targetLang} en échec: ${
+          (err as Error)?.message ?? err
+        }`,
+      );
+      return null;
+    }
+  }
+}

--- a/src/api/mangas/translation/description-translation.service.spec.ts
+++ b/src/api/mangas/translation/description-translation.service.spec.ts
@@ -133,8 +133,8 @@ describe('DescriptionTranslationService', () => {
     });
   });
 
-  describe('cache miss (hash différent) → provider + upsert', () => {
-    it('should re-translate and upsert when the source hash changed', async () => {
+  describe('cache périmé (hash différent) → stale-while-revalidate', () => {
+    it('should serve the STALE translation immediately and re-translate in background on hash mismatch', async () => {
       repo.findOneBy.mockResolvedValue({
         mu_id: '42',
         language: 'fr',
@@ -149,7 +149,12 @@ describe('DescriptionTranslationService', () => {
         'fr',
       );
 
-      expect(result).toBe('Nouvelle traduction.');
+      // SWR : le user reçoit tout de suite la traduction périmée (jamais
+      // l'anglais transitoire pendant la re-traduction).
+      expect(result).toBe('Traduction périmée.');
+
+      // La re-traduction se fait en arrière-plan et upserte pour le hit suivant.
+      await new Promise((r) => setTimeout(r, 0));
       expect(gtx.translate).toHaveBeenCalledWith(DESCRIPTION, 'fr');
       expect(insertQb.values).toHaveBeenCalledWith({
         mu_id: '42',
@@ -163,7 +168,9 @@ describe('DescriptionTranslationService', () => {
       );
       expect(insertQb.execute).toHaveBeenCalled();
     });
+  });
 
+  describe('cache miss (aucune traduction) → provider + upsert', () => {
     it('should try DeepL first when enabled, then fall back to gtx', async () => {
       deepl.isEnabled.mockReturnValue(true);
       deepl.translate.mockResolvedValue(null);
@@ -220,6 +227,52 @@ describe('DescriptionTranslationService', () => {
 
       expect(result).toBeNull();
       expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('negative-cache (échecs providers)', () => {
+    it('ne rappelle pas les providers pendant ~5 min après un échec total', async () => {
+      // Aucun cache existant ; gtx échoue → null.
+      gtx.translate.mockResolvedValue(null);
+
+      const first = await service.getTranslatedDescription(42, DESCRIPTION, 'fr');
+      expect(first).toBeNull();
+      expect(gtx.translate).toHaveBeenCalledTimes(1);
+
+      // 2e appel immédiat : negative-cache actif → aucun nouvel appel provider
+      // (on ne repaie pas le timeout de 4 s).
+      const second = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+      expect(second).toBeNull();
+      expect(gtx.translate).toHaveBeenCalledTimes(1);
+    });
+
+    it('sert le stale sans rappeler les providers quand un échec est en cache', async () => {
+      repo.findOneBy.mockResolvedValue({
+        mu_id: '42',
+        language: 'fr',
+        source_hash: sha256('old description'),
+        translated_description: 'Périmée.',
+      });
+      gtx.translate.mockResolvedValue(null); // le refresh de fond échoue
+
+      // 1er appel : SWR sert le stale et lance un refresh de fond qui échoue.
+      const first = await service.getTranslatedDescription(42, DESCRIPTION, 'fr');
+      expect(first).toBe('Périmée.');
+      await new Promise((r) => setTimeout(r, 0)); // laisse le refresh échouer
+      expect(gtx.translate).toHaveBeenCalledTimes(1);
+
+      // 2e appel : negative-cache actif → sert le stale sans rappeler gtx.
+      const second = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+      expect(second).toBe('Périmée.');
+      expect(gtx.translate).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/api/mangas/translation/description-translation.service.spec.ts
+++ b/src/api/mangas/translation/description-translation.service.spec.ts
@@ -1,0 +1,281 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { createHash } from 'node:crypto';
+import { DescriptionTranslationService } from './description-translation.service';
+import { MangaTranslation } from '../manga-translation.entity';
+import { DeeplProvider } from './deepl.provider';
+import { GtxProvider } from './gtx.provider';
+
+const sha256 = (text: string) =>
+  createHash('sha256').update(text).digest('hex');
+
+/** Query builder chainable pour l'upsert insert().orUpdate() */
+const createInsertQb = () => {
+  const qb: Record<string, jest.Mock> = {};
+  for (const method of ['insert', 'into', 'values', 'orUpdate']) {
+    qb[method] = jest.fn().mockReturnValue(qb);
+  }
+  qb.execute = jest.fn().mockResolvedValue({});
+  return qb;
+};
+
+describe('DescriptionTranslationService', () => {
+  let service: DescriptionTranslationService;
+  let repo: { findOneBy: jest.Mock; createQueryBuilder: jest.Mock };
+  let insertQb: Record<string, jest.Mock>;
+  let deepl: { isEnabled: jest.Mock; translate: jest.Mock };
+  let gtx: { translate: jest.Mock };
+
+  const DESCRIPTION = 'An epic story about a manga tracker.';
+
+  const buildService = async (timeoutMs?: number) => {
+    repo = {
+      findOneBy: jest.fn().mockResolvedValue(null),
+      createQueryBuilder: jest.fn(() => insertQb),
+    };
+    insertQb = createInsertQb();
+    deepl = {
+      isEnabled: jest.fn().mockReturnValue(false),
+      translate: jest.fn().mockResolvedValue(null),
+    };
+    gtx = { translate: jest.fn().mockResolvedValue(null) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DescriptionTranslationService,
+        { provide: getRepositoryToken(MangaTranslation), useValue: repo },
+        { provide: DeeplProvider, useValue: deepl },
+        { provide: GtxProvider, useValue: gtx },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'TRANSLATION_TIMEOUT_MS' && timeoutMs !== undefined
+                ? String(timeoutMs)
+                : undefined,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DescriptionTranslationService>(
+      DescriptionTranslationService,
+    );
+  };
+
+  beforeEach(async () => {
+    await buildService();
+  });
+
+  describe('parsePrimaryLang', () => {
+    it('should extract the primary subtag from a full Accept-Language header', () => {
+      expect(service.parsePrimaryLang('fr-FR,fr;q=0.9,en;q=0.8')).toBe('fr');
+      expect(service.parsePrimaryLang('pt-BR')).toBe('pt');
+      expect(service.parsePrimaryLang('JA')).toBe('ja');
+    });
+
+    it('should return null for a missing or invalid header', () => {
+      expect(service.parsePrimaryLang(undefined)).toBeNull();
+      expect(service.parsePrimaryLang('')).toBeNull();
+      expect(service.parsePrimaryLang('*')).toBeNull();
+      expect(service.parsePrimaryLang('  ;q=0.9')).toBeNull();
+    });
+  });
+
+  describe('passthrough (en / absent / non supporté)', () => {
+    it.each(['en', null, 'zz'])(
+      'should return null for lang=%p without any DB query nor provider call',
+      async (lang) => {
+        const result = await service.getTranslatedDescription(
+          42,
+          DESCRIPTION,
+          lang as string | null,
+        );
+
+        expect(result).toBeNull();
+        expect(repo.findOneBy).not.toHaveBeenCalled();
+        expect(deepl.translate).not.toHaveBeenCalled();
+        expect(gtx.translate).not.toHaveBeenCalled();
+      },
+    );
+
+    it('should return null for an empty source description', async () => {
+      expect(await service.getTranslatedDescription(42, '', 'fr')).toBeNull();
+      expect(gtx.translate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cache hit (hash égal)', () => {
+    it('should return the cached translation without calling any provider', async () => {
+      repo.findOneBy.mockResolvedValue({
+        mu_id: '42',
+        language: 'fr',
+        source_hash: sha256(DESCRIPTION),
+        translated_description: 'Une histoire épique.',
+      });
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBe('Une histoire épique.');
+      expect(repo.findOneBy).toHaveBeenCalledWith({
+        mu_id: '42',
+        language: 'fr',
+      });
+      expect(deepl.translate).not.toHaveBeenCalled();
+      expect(gtx.translate).not.toHaveBeenCalled();
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cache miss (hash différent) → provider + upsert', () => {
+    it('should re-translate and upsert when the source hash changed', async () => {
+      repo.findOneBy.mockResolvedValue({
+        mu_id: '42',
+        language: 'fr',
+        source_hash: sha256('old description'),
+        translated_description: 'Traduction périmée.',
+      });
+      gtx.translate.mockResolvedValue('Nouvelle traduction.');
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBe('Nouvelle traduction.');
+      expect(gtx.translate).toHaveBeenCalledWith(DESCRIPTION, 'fr');
+      expect(insertQb.values).toHaveBeenCalledWith({
+        mu_id: '42',
+        language: 'fr',
+        source_hash: sha256(DESCRIPTION),
+        translated_description: 'Nouvelle traduction.',
+      });
+      expect(insertQb.orUpdate).toHaveBeenCalledWith(
+        ['source_hash', 'translated_description', 'updated_at'],
+        ['mu_id', 'language'],
+      );
+      expect(insertQb.execute).toHaveBeenCalled();
+    });
+
+    it('should try DeepL first when enabled, then fall back to gtx', async () => {
+      deepl.isEnabled.mockReturnValue(true);
+      deepl.translate.mockResolvedValue(null);
+      gtx.translate.mockResolvedValue('Fallback gtx.');
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBe('Fallback gtx.');
+      expect(deepl.translate).toHaveBeenCalledWith(DESCRIPTION, 'fr');
+      expect(gtx.translate).toHaveBeenCalledWith(DESCRIPTION, 'fr');
+    });
+
+    it('should not call gtx when DeepL succeeds', async () => {
+      deepl.isEnabled.mockReturnValue(true);
+      deepl.translate.mockResolvedValue('Via DeepL.');
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBe('Via DeepL.');
+      expect(gtx.translate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('échec provider', () => {
+    it('should return null (original description côté controller) when all providers fail', async () => {
+      gtx.translate.mockResolvedValue(null);
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBeNull();
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should return null when the provider rejects (never a 5xx)', async () => {
+      gtx.translate.mockRejectedValue(new Error('network down'));
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      expect(result).toBeNull();
+      expect(repo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('timeout → null immédiat + upsert différé', () => {
+    it('should return null after the timeout but still upsert in background', async () => {
+      await buildService(20);
+      gtx.translate.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve('Traduction tardive.'), 60),
+          ),
+      );
+
+      const result = await service.getTranslatedDescription(
+        42,
+        DESCRIPTION,
+        'fr',
+      );
+
+      // Timeout (20 ms) < durée provider (60 ms) → null immédiat.
+      expect(result).toBeNull();
+      expect(insertQb.execute).not.toHaveBeenCalled();
+
+      // La promesse continue en arrière-plan et upserte pour le visiteur
+      // suivant (pattern fire-and-forget).
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(insertQb.values).toHaveBeenCalledWith({
+        mu_id: '42',
+        language: 'fr',
+        source_hash: sha256(DESCRIPTION),
+        translated_description: 'Traduction tardive.',
+      });
+      expect(insertQb.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('dédup in-flight', () => {
+    it('should translate only once for concurrent requests on the same (manga, lang)', async () => {
+      let resolveTranslate: (value: string) => void;
+      gtx.translate.mockImplementation(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveTranslate = resolve;
+          }),
+      );
+
+      const p1 = service.getTranslatedDescription(42, DESCRIPTION, 'fr');
+      const p2 = service.getTranslatedDescription(42, DESCRIPTION, 'fr');
+      // Laisse les deux appels dépasser le findOneBy et rejoindre la même
+      // promesse in-flight avant de résoudre le provider.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      resolveTranslate('Une seule traduction.');
+
+      expect(await p1).toBe('Une seule traduction.');
+      expect(await p2).toBe('Une seule traduction.');
+      expect(gtx.translate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/api/mangas/translation/description-translation.service.ts
+++ b/src/api/mangas/translation/description-translation.service.ts
@@ -1,0 +1,217 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHash } from 'node:crypto';
+import { Repository } from 'typeorm';
+import { MangaTranslation } from '../manga-translation.entity';
+import { DeeplProvider } from './deepl.provider';
+import { GtxProvider } from './gtx.provider';
+import { TranslationProvider } from './translation-provider.interface';
+
+/**
+ * Langues cibles supportées. `en` n'y figure pas : la source MU est en
+ * anglais → passthrough (la description originale est renvoyée telle
+ * quelle, sans appel provider ni ligne en base).
+ */
+export const SUPPORTED_TARGET_LANGS: readonly string[] = [
+  'fr',
+  'de',
+  'es',
+  'pt',
+  'ja',
+  'ko',
+];
+
+/** Timeout dur par défaut sur la traduction synchrone (1er visiteur) */
+export const DEFAULT_TRANSLATION_TIMEOUT_MS = 4000;
+
+/**
+ * Traduction des descriptions manga côté serveur (Chantier A).
+ *
+ * Service dédié — ne PAS fusionner dans `MangasService` (déjà au-dessus de
+ * la limite des 400 lignes).
+ *
+ * Stratégie :
+ * 1. Cache Postgres `manga_translation` clé (mu_id, language), invalidé par
+ *    `source_hash` (sha256 de la description MU live).
+ * 2. Miss → cascade providers (DeepL si clé, sinon gtx) bornée par un
+ *    timeout dur (`TRANSLATION_TIMEOUT_MS`, défaut 4 s). Timeout/échec →
+ *    `null` (le controller renvoie l'original) mais la promesse continue en
+ *    arrière-plan et upserte pour le visiteur suivant.
+ * 3. Dédup in-flight : une seule traduction simultanée par (manga, langue).
+ */
+@Injectable()
+export class DescriptionTranslationService {
+  private readonly logger = new Logger(DescriptionTranslationService.name);
+  private readonly timeoutMs: number;
+
+  /** Dédup in-flight : "<muId>:<lang>" → promesse de traduction en cours */
+  private readonly inFlight = new Map<string, Promise<string | null>>();
+
+  constructor(
+    @InjectRepository(MangaTranslation)
+    private readonly translationRepository: Repository<MangaTranslation>,
+    private readonly deeplProvider: DeeplProvider,
+    private readonly gtxProvider: GtxProvider,
+    configService: ConfigService,
+  ) {
+    const configured = Number(
+      configService.get<string>('TRANSLATION_TIMEOUT_MS'),
+    );
+    this.timeoutMs =
+      Number.isFinite(configured) && configured > 0
+        ? configured
+        : DEFAULT_TRANSLATION_TIMEOUT_MS;
+  }
+
+  /**
+   * Extrait le sous-tag primaire du header `Accept-Language`.
+   * Ex. : `fr-FR,fr;q=0.9` → `fr` ; `pt-BR` → `pt` ; absent/invalide → null.
+   */
+  parsePrimaryLang(acceptLanguage?: string): string | null {
+    if (!acceptLanguage) return null;
+    const first = acceptLanguage.split(',')[0]?.split(';')[0]?.trim();
+    if (!first) return null;
+    const primary = first.split('-')[0].toLowerCase();
+    return /^[a-z]{2,3}$/.test(primary) ? primary : null;
+  }
+
+  /**
+   * Retourne la description traduite pour (`muId`, `lang`), ou `null` si :
+   * - `lang` est absent, `en`, ou hors langues supportées (passthrough) ;
+   * - la traduction échoue ou dépasse le timeout (elle continue alors en
+   *   arrière-plan et sera servie depuis le cache au hit suivant).
+   *
+   * Ne rejette jamais — une traduction ratée ne produit pas de 5xx.
+   */
+  async getTranslatedDescription(
+    muId: number,
+    sourceDescription: string,
+    lang: string | null,
+  ): Promise<string | null> {
+    const normalized = (lang ?? '').trim().toLowerCase();
+    if (!SUPPORTED_TARGET_LANGS.includes(normalized)) return null;
+    if (!sourceDescription || sourceDescription.trim().length === 0) {
+      return null;
+    }
+
+    const hash = createHash('sha256').update(sourceDescription).digest('hex');
+
+    const existing = await this.translationRepository.findOneBy({
+      mu_id: muId.toString(),
+      language: normalized,
+    });
+    if (existing && existing.source_hash === hash) {
+      // Hit : hash identique → zéro appel externe.
+      return existing.translated_description;
+    }
+
+    const key = `${muId}:${normalized}`;
+    let job = this.inFlight.get(key);
+    if (!job) {
+      job = this.translateAndPersist(
+        muId,
+        normalized,
+        sourceDescription,
+        hash,
+      ).finally(() => this.inFlight.delete(key));
+      this.inFlight.set(key, job);
+    }
+
+    // Timeout dur : au-delà, on renvoie null (→ description originale) mais
+    // `job` continue et upserte en arrière-plan pour le visiteur suivant.
+    return this.raceWithTimeout(job, this.timeoutMs);
+  }
+
+  /**
+   * Cascade providers (DeepL si clé configurée, puis gtx) + upsert du
+   * résultat. Résout toujours (jamais de rejet) : `null` = échec total.
+   */
+  private async translateAndPersist(
+    muId: number,
+    lang: string,
+    sourceDescription: string,
+    sourceHash: string,
+  ): Promise<string | null> {
+    const providers: TranslationProvider[] = this.deeplProvider.isEnabled()
+      ? [this.deeplProvider, this.gtxProvider]
+      : [this.gtxProvider];
+
+    for (const provider of providers) {
+      let translated: string | null = null;
+      try {
+        translated = await provider.translate(sourceDescription, lang);
+      } catch (err) {
+        // Les providers ne devraient jamais rejeter (contrat) — ceinture
+        // et bretelles pour garantir "jamais de 5xx pour une traduction".
+        this.logger.warn(
+          `Provider ${provider.name} a rejeté pour ${muId}:${lang}: ${
+            (err as Error)?.message ?? err
+          }`,
+        );
+      }
+      if (translated) {
+        await this.upsertTranslation(muId, lang, sourceHash, translated).catch(
+          (err) =>
+            this.logger.warn(
+              `Upsert traduction ${muId}:${lang} en échec: ${
+                (err as Error)?.message ?? err
+              }`,
+            ),
+        );
+        return translated;
+      }
+    }
+
+    this.logger.warn(
+      `Aucun provider n'a pu traduire la description de ${muId} en ${lang}`,
+    );
+    return null;
+  }
+
+  /** Upsert idempotent sur l'index UNIQUE (mu_id, language) */
+  private async upsertTranslation(
+    muId: number,
+    lang: string,
+    sourceHash: string,
+    translatedDescription: string,
+  ): Promise<void> {
+    await this.translationRepository
+      .createQueryBuilder()
+      .insert()
+      .into(MangaTranslation)
+      .values({
+        mu_id: muId.toString(),
+        language: lang,
+        source_hash: sourceHash,
+        translated_description: translatedDescription,
+      })
+      .orUpdate(
+        ['source_hash', 'translated_description', 'updated_at'],
+        ['mu_id', 'language'],
+      )
+      .execute();
+  }
+
+  /**
+   * Course promesse vs timeout. Ne rejette jamais : échec ou timeout →
+   * `null`. Le timer est toujours nettoyé (pas de handle qui traîne).
+   */
+  private raceWithTimeout(
+    promise: Promise<string | null>,
+    timeoutMs: number,
+  ): Promise<string | null> {
+    return new Promise<string | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), timeoutMs);
+      promise
+        .then((value) => {
+          clearTimeout(timer);
+          resolve(value);
+        })
+        .catch(() => {
+          clearTimeout(timer);
+          resolve(null);
+        });
+    });
+  }
+}

--- a/src/api/mangas/translation/description-translation.service.ts
+++ b/src/api/mangas/translation/description-translation.service.ts
@@ -26,6 +26,13 @@ export const SUPPORTED_TARGET_LANGS: readonly string[] = [
 export const DEFAULT_TRANSLATION_TIMEOUT_MS = 4000;
 
 /**
+ * Durée du negative-cache : après un échec total des providers pour un couple
+ * (manga, langue), on ne retente pas (et on ne repaie donc pas le timeout de
+ * {@link DEFAULT_TRANSLATION_TIMEOUT_MS}) pendant cette fenêtre.
+ */
+export const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
  * Traduction des descriptions manga côté serveur (Chantier A).
  *
  * Service dédié — ne PAS fusionner dans `MangasService` (déjà au-dessus de
@@ -34,11 +41,16 @@ export const DEFAULT_TRANSLATION_TIMEOUT_MS = 4000;
  * Stratégie :
  * 1. Cache Postgres `manga_translation` clé (mu_id, language), invalidé par
  *    `source_hash` (sha256 de la description MU live).
- * 2. Miss → cascade providers (DeepL si clé, sinon gtx) bornée par un
+ * 2. Cache PÉRIMÉ (hash différent) → stale-while-revalidate : on sert la
+ *    traduction périmée IMMÉDIATEMENT et on re-traduit en arrière-plan (le
+ *    visiteur ne retombe pas sur l'anglais pendant la re-traduction).
+ * 3. Aucun cache → cascade providers (DeepL si clé, sinon gtx) bornée par un
  *    timeout dur (`TRANSLATION_TIMEOUT_MS`, défaut 4 s). Timeout/échec →
  *    `null` (le controller renvoie l'original) mais la promesse continue en
  *    arrière-plan et upserte pour le visiteur suivant.
- * 3. Dédup in-flight : une seule traduction simultanée par (manga, langue).
+ * 4. Negative-cache court ({@link NEGATIVE_CACHE_TTL_MS}) : après un échec
+ *    total, on ne repaie pas le timeout à chaque requête (skip ~5 min).
+ * 5. Dédup in-flight : une seule traduction simultanée par (manga, langue).
  */
 @Injectable()
 export class DescriptionTranslationService {
@@ -47,6 +59,13 @@ export class DescriptionTranslationService {
 
   /** Dédup in-flight : "<muId>:<lang>" → promesse de traduction en cours */
   private readonly inFlight = new Map<string, Promise<string | null>>();
+
+  /**
+   * Negative-cache : "<muId>:<lang>" → timestamp (ms) du dernier échec total.
+   * Une entrée plus récente que {@link NEGATIVE_CACHE_TTL_MS} court-circuite
+   * la traduction (évite de repayer le timeout providers à chaque requête).
+   */
+  private readonly negativeCache = new Map<string, number>();
 
   constructor(
     @InjectRepository(MangaTranslation)
@@ -79,10 +98,12 @@ export class DescriptionTranslationService {
   /**
    * Retourne la description traduite pour (`muId`, `lang`), ou `null` si :
    * - `lang` est absent, `en`, ou hors langues supportées (passthrough) ;
-   * - la traduction échoue ou dépasse le timeout (elle continue alors en
-   *   arrière-plan et sera servie depuis le cache au hit suivant).
+   * - la traduction échoue ou dépasse le timeout ET aucune traduction (même
+   *   périmée) n'est disponible.
    *
-   * Ne rejette jamais — une traduction ratée ne produit pas de 5xx.
+   * Stale-while-revalidate : une traduction périmée est servie immédiatement
+   * et re-traduite en arrière-plan. Ne rejette jamais — une traduction ratée
+   * ne produit pas de 5xx.
    */
   async getTranslatedDescription(
     muId: number,
@@ -107,20 +128,50 @@ export class DescriptionTranslationService {
     }
 
     const key = `${muId}:${normalized}`;
+
+    // Negative-cache : un échec récent → on ne repaie pas le timeout. On sert
+    // le stale s'il existe, sinon null (→ description originale côté controller).
+    if (this.isNegativelyCached(key)) {
+      return existing?.translated_description ?? null;
+    }
+
+    // Lance (ou réutilise) la traduction. Le résultat alimente le
+    // negative-cache (échec) ou le purge (succès).
     let job = this.inFlight.get(key);
     if (!job) {
-      job = this.translateAndPersist(
-        muId,
-        normalized,
-        sourceDescription,
-        hash,
-      ).finally(() => this.inFlight.delete(key));
+      job = this.translateAndPersist(muId, normalized, sourceDescription, hash)
+        .then((result) => {
+          if (result === null) this.negativeCache.set(key, Date.now());
+          else this.negativeCache.delete(key);
+          return result;
+        })
+        .finally(() => this.inFlight.delete(key));
       this.inFlight.set(key, job);
     }
 
-    // Timeout dur : au-delà, on renvoie null (→ description originale) mais
-    // `job` continue et upserte en arrière-plan pour le visiteur suivant.
+    // Stale-while-revalidate : on a une traduction PÉRIMÉE → on la sert tout
+    // de suite (pas d'anglais transitoire), la re-traduction se fait en fond.
+    if (existing) {
+      return existing.translated_description;
+    }
+
+    // Aucun cache : traduction synchrone bornée par le timeout. Au-delà, null
+    // (→ description originale) mais `job` continue et upserte pour le suivant.
     return this.raceWithTimeout(job, this.timeoutMs);
+  }
+
+  /**
+   * `true` si un échec de traduction pour cette clé est en cache depuis moins
+   * de {@link NEGATIVE_CACHE_TTL_MS}. Purge l'entrée expirée au passage.
+   */
+  private isNegativelyCached(key: string): boolean {
+    const failedAt = this.negativeCache.get(key);
+    if (failedAt === undefined) return false;
+    if (Date.now() - failedAt > NEGATIVE_CACHE_TTL_MS) {
+      this.negativeCache.delete(key);
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/api/mangas/translation/gtx.provider.spec.ts
+++ b/src/api/mangas/translation/gtx.provider.spec.ts
@@ -1,0 +1,96 @@
+import { of, throwError } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+import {
+  GtxProvider,
+  GTX_MAX_CHUNK_LENGTH,
+  splitOnSentenceBoundary,
+} from './gtx.provider';
+
+describe('splitOnSentenceBoundary', () => {
+  it('should return the text as a single chunk when under the limit', () => {
+    expect(splitOnSentenceBoundary('Short text.', 3500)).toEqual([
+      'Short text.',
+    ]);
+  });
+
+  it('should split on sentence boundaries without cutting a sentence in half', () => {
+    const sentence = 'A'.repeat(30) + '. ';
+    const text = sentence.repeat(10); // 320 caractères
+
+    const chunks = splitOnSentenceBoundary(text, 100);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(100);
+      // Chaque chunk se termine sur une frontière de phrase.
+      expect(chunk.trimEnd().endsWith('.')).toBe(true);
+    }
+    expect(chunks.join('')).toBe(text);
+  });
+
+  it('should hard-split a degenerate sentence longer than the limit', () => {
+    const text = 'B'.repeat(250); // aucune ponctuation
+
+    const chunks = splitOnSentenceBoundary(text, 100);
+
+    expect(chunks.every((c) => c.length <= 100)).toBe(true);
+    expect(chunks.join('')).toBe(text);
+  });
+});
+
+describe('GtxProvider', () => {
+  const gtxResponse = (translated: string) =>
+    of({ data: [[[translated, 'source', null]]] });
+
+  it('should translate a short text in a single call and parse the gtx payload', async () => {
+    const get = jest.fn().mockReturnValue(gtxResponse('Bonjour le monde.'));
+    const provider = new GtxProvider({ get } as unknown as HttpService);
+
+    const result = await provider.translate('Hello world.', 'fr');
+
+    expect(result).toBe('Bonjour le monde.');
+    expect(get).toHaveBeenCalledTimes(1);
+    const url: string = get.mock.calls[0][0];
+    expect(url).toContain('client=gtx');
+    expect(url).toContain('tl=fr');
+    expect(url).toContain(`q=${encodeURIComponent('Hello world.')}`);
+  });
+
+  it('should chunk a long description (~3500 chars per call) and join the results', async () => {
+    const sentence = 'This is a sentence about manga. ';
+    const longText = sentence.repeat(200); // 6400 caractères > 3500
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(gtxResponse('Chunk un.'))
+      .mockReturnValueOnce(gtxResponse('Chunk deux.'));
+    const provider = new GtxProvider({ get } as unknown as HttpService);
+
+    const result = await provider.translate(longText, 'fr');
+
+    expect(get).toHaveBeenCalledTimes(2);
+    for (const call of get.mock.calls) {
+      // Chunk borné AVANT encodage URL.
+      const encoded = (call[0] as string).split('&q=')[1];
+      expect(decodeURIComponent(encoded).length).toBeLessThanOrEqual(
+        GTX_MAX_CHUNK_LENGTH,
+      );
+    }
+    expect(result).toBe('Chunk un. Chunk deux.');
+  });
+
+  it('should return null (never throw) when the endpoint fails', async () => {
+    const get = jest
+      .fn()
+      .mockReturnValue(throwError(() => new Error('403 banned')));
+    const provider = new GtxProvider({ get } as unknown as HttpService);
+
+    await expect(provider.translate('Hello.', 'fr')).resolves.toBeNull();
+  });
+
+  it('should return null when the payload has no translated segments', async () => {
+    const get = jest.fn().mockReturnValue(of({ data: [] }));
+    const provider = new GtxProvider({ get } as unknown as HttpService);
+
+    await expect(provider.translate('Hello.', 'fr')).resolves.toBeNull();
+  });
+});

--- a/src/api/mangas/translation/gtx.provider.ts
+++ b/src/api/mangas/translation/gtx.provider.ts
@@ -1,0 +1,120 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+import { TranslationProvider } from './translation-provider.interface';
+
+export const GTX_API_URL =
+  'https://translate.googleapis.com/translate_a/single';
+
+/**
+ * Taille max d'un chunk AVANT encodage URL. L'endpoint gtx est un GET :
+ * une description MU longue encodée (~×3 en worst case UTF-8) peut dépasser
+ * la limite d'URL (~8-16k selon les fronts). 3500 caractères laissent une
+ * marge confortable.
+ */
+export const GTX_MAX_CHUNK_LENGTH = 3500;
+
+/**
+ * Découpe `text` en chunks de `maxLen` caractères max, en coupant sur les
+ * frontières de phrase (ponctuation finale ou fin de ligne) pour ne pas
+ * couper une phrase en deux — la traduction d'une demi-phrase est mauvaise.
+ * Une phrase isolée plus longue que `maxLen` est hard-splittée (cas
+ * dégénéré, jamais vu sur des descriptions MU réelles).
+ */
+export function splitOnSentenceBoundary(
+  text: string,
+  maxLen: number,
+): string[] {
+  if (text.length <= maxLen) return [text];
+
+  // Une "phrase" = tout jusqu'à une ponctuation finale (./!/?) ou un saut
+  // de ligne inclus, espaces suivants compris ; le dernier fragment sans
+  // ponctuation finale est capturé par la 2ᵉ alternative.
+  const sentences = text.match(/[^.!?\n]*[.!?\n]+\s*|[^.!?\n]+$/g) ?? [text];
+
+  const chunks: string[] = [];
+  let current = '';
+  for (const sentence of sentences) {
+    const pieces: string[] = [];
+    if (sentence.length > maxLen) {
+      for (let i = 0; i < sentence.length; i += maxLen) {
+        pieces.push(sentence.slice(i, i + maxLen));
+      }
+    } else {
+      pieces.push(sentence);
+    }
+    for (const piece of pieces) {
+      if (current.length > 0 && current.length + piece.length > maxLen) {
+        chunks.push(current);
+        current = '';
+      }
+      current += piece;
+    }
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * Provider Google Translate non officiel (`client=gtx`) — fallback
+ * zéro-config quand DeepL n'a pas de clé ou échoue. Port serveur de
+ * l'ancien `_translateWithGoogleTranslate` du front Flutter.
+ *
+ * Fragile par nature (endpoint non documenté, bannissable par IP) mais le
+ * trafic serveur est minuscule : 1 appel par (manga, langue, changement de
+ * description) grâce au cache `manga_translation`.
+ */
+@Injectable()
+export class GtxProvider implements TranslationProvider {
+  readonly name = 'gtx';
+
+  private readonly logger = new Logger(GtxProvider.name);
+
+  constructor(private readonly httpService: HttpService) {}
+
+  async translate(text: string, targetLang: string): Promise<string | null> {
+    try {
+      const chunks = splitOnSentenceBoundary(text, GTX_MAX_CHUNK_LENGTH);
+      const translatedChunks: string[] = [];
+      for (const chunk of chunks) {
+        const translated = await this.translateChunk(chunk, targetLang);
+        // Un chunk raté = traduction partielle → on abandonne tout (le
+        // caller renverra la description originale, jamais un mélange).
+        if (translated === null) return null;
+        translatedChunks.push(translated);
+      }
+      const joined = translatedChunks.join(' ').trim();
+      return joined.length > 0 ? joined : null;
+    } catch (err) {
+      this.logger.warn(
+        `gtx translate vers ${targetLang} en échec: ${
+          (err as Error)?.message ?? err
+        }`,
+      );
+      return null;
+    }
+  }
+
+  private async translateChunk(
+    chunk: string,
+    targetLang: string,
+  ): Promise<string | null> {
+    const url =
+      `${GTX_API_URL}?client=gtx&sl=en&tl=${encodeURIComponent(targetLang)}` +
+      `&dt=t&q=${encodeURIComponent(chunk)}`;
+
+    const { data } = await firstValueFrom(this.httpService.get<unknown[]>(url));
+
+    // Format gtx : data[0] = [[segTraduit, segSource, ...], ...] — on
+    // concatène les premiers éléments de chaque segment.
+    const segments = Array.isArray(data?.[0]) ? (data[0] as unknown[]) : null;
+    if (!segments) return null;
+
+    const joined = segments
+      .map((seg) =>
+        Array.isArray(seg) && typeof seg[0] === 'string' ? seg[0] : '',
+      )
+      .join('');
+    return joined.length > 0 ? joined : null;
+  }
+}

--- a/src/api/mangas/translation/translation-provider.interface.ts
+++ b/src/api/mangas/translation/translation-provider.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * Contrat commun des moteurs de traduction (Chantier A).
+ *
+ * Implémentations actuelles :
+ * - `DeeplProvider` — DeepL API Free, actif uniquement si `DEEPL_API_KEY`
+ *   est défini (primaire, meilleure qualité).
+ * - `GtxProvider` — endpoint Google Translate non officiel `client=gtx`,
+ *   zéro configuration (fallback / défaut).
+ *
+ * L'interface permet d'ajouter plus tard un 3ᵉ provider (ex. LibreTranslate
+ * self-hosted sur le NAS) sans toucher au `DescriptionTranslationService`.
+ */
+export interface TranslationProvider {
+  /** Nom court du provider (logs/debug) */
+  readonly name: string;
+
+  /**
+   * Traduit `text` (anglais) vers `targetLang` (code primaire 2 lettres,
+   * minuscule : fr, de, es, pt, ja, ko).
+   *
+   * @returns la traduction, ou `null` en cas d'échec (quota, réseau,
+   * provider inactif…). Ne rejette JAMAIS : une traduction ratée ne doit
+   * jamais produire de 5xx — le caller renverra la description originale.
+   */
+  translate(text: string, targetLang: string): Promise<string | null>;
+}

--- a/src/api/recommendations/catalog-candidate.service.spec.ts
+++ b/src/api/recommendations/catalog-candidate.service.spec.ts
@@ -1,0 +1,204 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CatalogCandidateService } from './catalog-candidate.service';
+import { Manga } from '@/api/mangas/manga.entity';
+import { UserManga } from '@/api/mangas/user-manga.entity';
+import { NSFW_GENRES } from '@/api/mangas/constants';
+import { ReadingStatus } from '@/api/library/reading-status.enum';
+
+function makeManga(overrides: Partial<Manga> = {}): Manga {
+  const manga = new Manga();
+  manga.id = 1;
+  manga.mu_id = '1000';
+  manga.title = 'Manga 1000';
+  manga.rating = 8.0;
+  manga.genres = ['Action'];
+  return Object.assign(manga, overrides);
+}
+
+function makeUserManga(overrides: Partial<UserManga> = {}): UserManga {
+  const um = new UserManga();
+  um.id = 1;
+  um.user_rating = 0;
+  um.readingStatus = ReadingStatus.Reading;
+  um.adding_date = new Date(); // récent → recency ~1.0
+  um.manga = makeManga();
+  return Object.assign(um, overrides);
+}
+
+describe('CatalogCandidateService', () => {
+  let service: CatalogCandidateService;
+  let qb: {
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    orderBy: jest.Mock;
+    limit: jest.Mock;
+    getMany: jest.Mock;
+  };
+  let mangaRepo: { createQueryBuilder: jest.Mock };
+
+  /** Récupère les params passés au andWhere qui contient `fragment`. */
+  function paramsOf(fragment: string): Record<string, unknown> | undefined {
+    const call = qb.andWhere.mock.calls.find((c) =>
+      (c[0] as string).includes(fragment),
+    );
+    return call?.[1] as Record<string, unknown> | undefined;
+  }
+
+  beforeEach(async () => {
+    qb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    mangaRepo = { createQueryBuilder: jest.fn(() => qb) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CatalogCandidateService,
+        { provide: getRepositoryToken(Manga), useValue: mangaRepo },
+      ],
+    }).compile();
+
+    service = module.get<CatalogCandidateService>(CatalogCandidateService);
+  });
+
+  describe('genres favoris', () => {
+    it('interroge le catalogue avec le top 5 des genres de la biblio', async () => {
+      // Action×3, Romance×2, Comedy/Drama/Fantasy×1, Horror×1 (6 genres).
+      const library = [
+        makeUserManga({
+          manga: makeManga({ mu_id: '1', genres: ['Action', 'Romance'] }),
+        }),
+        makeUserManga({
+          id: 2,
+          manga: makeManga({ mu_id: '2', genres: ['Action', 'Romance'] }),
+        }),
+        makeUserManga({
+          id: 3,
+          manga: makeManga({ mu_id: '3', genres: ['Action', 'Comedy'] }),
+        }),
+        makeUserManga({
+          id: 4,
+          manga: makeManga({ mu_id: '4', genres: ['Drama', 'Fantasy'] }),
+        }),
+        makeUserManga({
+          id: 5,
+          manga: makeManga({ mu_id: '5', genres: ['Horror'] }),
+        }),
+      ];
+
+      await service.findCandidates(library, new Set());
+
+      const params = paramsOf('topGenres');
+      expect(params).toBeDefined();
+      const topGenres = params!.topGenres as string[];
+      expect(topGenres).toHaveLength(5);
+      expect(topGenres).toContain('Action');
+      expect(topGenres).toContain('Romance');
+      // 6 genres en biblio → un seul est exclu du top 5.
+      const all = ['Action', 'Romance', 'Comedy', 'Drama', 'Fantasy', 'Horror'];
+      expect(all.filter((g) => !topGenres.includes(g))).toHaveLength(1);
+    });
+
+    it('retourne [] sans requête si la biblio n’a aucun genre', async () => {
+      const library = [
+        makeUserManga({ manga: makeManga({ genres: undefined }) }),
+      ];
+      const result = await service.findCandidates(library, new Set());
+      expect(result).toEqual([]);
+      expect(mangaRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('formule de score', () => {
+    it('candidat mono-genre rating 9 → 8 × 1 × (0.5 + 0.5 × 5/7) ≈ 6.86, sous une reco MU forte (12)', async () => {
+      // Biblio mono-genre : share(Action) = 1.
+      const library = [
+        makeUserManga({ manga: makeManga({ genres: ['Action'] }) }),
+      ];
+      qb.getMany.mockResolvedValue([
+        makeManga({ mu_id: '9000', rating: 9, genres: ['Action'] }),
+      ]);
+
+      const result = await service.findCandidates(library, new Set());
+
+      expect(result).toHaveLength(1);
+      // ratingBoost = clamp((9 − 6.5) / 3.5, 0, 1) = 0.7142…
+      expect(result[0].score).toBeCloseTo(8 * 1 * (0.5 + 0.5 * (2.5 / 3.5)), 4);
+      // Ne double jamais une reco MU forte (weight 10 × multiplier 1.2 = 12).
+      expect(result[0].score).toBeLessThan(12);
+    });
+
+    it('borne ratingBoost à [0, 1] (rating 10 → boost 1)', async () => {
+      const library = [
+        makeUserManga({ manga: makeManga({ genres: ['Action'] }) }),
+      ];
+      qb.getMany.mockResolvedValue([
+        makeManga({ mu_id: '9000', rating: 10, genres: ['Action'] }),
+      ]);
+
+      const result = await service.findCandidates(library, new Set());
+      expect(result[0].score).toBeCloseTo(8 * 1 * (0.5 + 0.5 * 1), 4);
+    });
+
+    it('sourceMuIds = les 2 mangas biblio au multiplicateur le plus élevé sur le genre dominant', async () => {
+      const library = [
+        makeUserManga({
+          manga: makeManga({ mu_id: '1000', genres: ['Action'] }),
+          readingStatus: ReadingStatus.Completed, // ×1.5
+        }),
+        makeUserManga({
+          id: 2,
+          manga: makeManga({ id: 2, mu_id: '1001', genres: ['Action'] }),
+          readingStatus: ReadingStatus.Reading, // ×1.2
+        }),
+        makeUserManga({
+          id: 3,
+          manga: makeManga({ id: 3, mu_id: '1002', genres: ['Action'] }),
+          readingStatus: ReadingStatus.ReadLater, // ×0.8
+        }),
+      ];
+      qb.getMany.mockResolvedValue([
+        makeManga({ mu_id: '9000', rating: 8, genres: ['Action'] }),
+      ]);
+
+      const result = await service.findCandidates(library, new Set());
+      expect(result[0].sourceMuIds).toEqual(['1000', '1001']);
+    });
+  });
+
+  describe('paramètres SQL', () => {
+    it('exclut la biblio, les genres NSFW, et applique le plancher de note + tri/limit', async () => {
+      const library = [
+        makeUserManga({ manga: makeManga({ mu_id: '1000' }) }),
+        makeUserManga({
+          id: 2,
+          manga: makeManga({ id: 2, mu_id: '1001' }),
+        }),
+      ];
+
+      await service.findCandidates(library, new Set(['1000', '1001']));
+
+      expect(qb.where).toHaveBeenCalledWith('m.genres IS NOT NULL');
+      const nsfwParams = paramsOf('nsfwGenres');
+      expect(nsfwParams!.nsfwGenres).toEqual(NSFW_GENRES);
+      const floorParams = paramsOf('ratingFloor');
+      expect(floorParams!.ratingFloor).toBe(7.0);
+      const excludeParams = paramsOf('excludeMuIds');
+      expect(excludeParams!.excludeMuIds).toEqual(
+        expect.arrayContaining(['1000', '1001']),
+      );
+      expect(qb.orderBy).toHaveBeenCalledWith('m.rating', 'DESC');
+      expect(qb.limit).toHaveBeenCalledWith(300);
+    });
+
+    it("n'ajoute pas de clause NOT IN quand excludeMuIds est vide", async () => {
+      const library = [makeUserManga()];
+      await service.findCandidates(library, new Set());
+      expect(paramsOf('excludeMuIds')).toBeUndefined();
+    });
+  });
+});

--- a/src/api/recommendations/catalog-candidate.service.ts
+++ b/src/api/recommendations/catalog-candidate.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Manga } from '@/api/mangas/manga.entity';
+import { UserManga } from '@/api/mangas/user-manga.entity';
+import { NSFW_GENRES } from '@/api/mangas/constants';
+
+/**
+ * Candidat issu du catalogue local (table `manga` alimentée par
+ * CatalogSyncService), scoré par affinité de genres avec la bibliothèque.
+ */
+export interface CatalogCandidate {
+  mu_id: string;
+  score: number;
+  /**
+   * mu_id des 2 mangas biblio au multiplicateur le plus élevé partageant le
+   * genre dominant du candidat — alimente `recommendedBecauseOf`.
+   */
+  sourceMuIds: string[];
+}
+
+/**
+ * Complète le pool de recommandations MU (longue traîne) avec des candidats
+ * du catalogue local quand le scoring MU remonte trop peu de titres
+ * (< CATALOG_MIN_POOL côté RecommendationService).
+ *
+ * Score : `CATALOG_BASE_WEIGHT × genreScore × (0.5 + 0.5 × ratingBoost)`
+ * - `genreScore` = Σ share(g) des genres favoris matchés (share = part du
+ *   genre dans les occurrences de la biblio) ;
+ * - `ratingBoost` = clamp((rating − 6.5) / 3.5, 0, 1).
+ * Plage effective ~0.5-6 : complète sans jamais doubler une reco MU forte
+ * (contributions typiques 2-25).
+ */
+@Injectable()
+export class CatalogCandidateService {
+  private readonly logger = new Logger(CatalogCandidateService.name);
+
+  /** Poids de base d'un candidat catalogue (vs weight MU 2-25). */
+  private static readonly CATALOG_BASE_WEIGHT = 8;
+
+  /** Note MU minimale d'un candidat catalogue. */
+  private static readonly RATING_FLOOR = 7.0;
+
+  /** Nombre de genres favoris considérés. */
+  private static readonly TOP_GENRES = 5;
+
+  /** Lignes max remontées par la requête (seq scan ok < 100k lignes). */
+  private static readonly QUERY_LIMIT = 300;
+
+  /** Nombre de mangas sources exposés par candidat (explicabilité). */
+  private static readonly SOURCES_PER_CANDIDATE = 2;
+
+  /**
+   * Miroir de `RecommendationService.STATUS_MULTIPLIER` /
+   * `RECENCY_HALF_LIFE_DAYS` — utilisé uniquement pour choisir les mangas
+   * sources les plus représentatifs (pas pour le score du candidat).
+   */
+  private static readonly STATUS_MULTIPLIER: Record<string, number> = {
+    completed: 1.5,
+    caughtUp: 1.3,
+    reading: 1.2,
+    readLater: 0.8,
+  };
+
+  private static readonly RECENCY_HALF_LIFE_DAYS = 365;
+
+  constructor(
+    @InjectRepository(Manga)
+    private readonly mangaRepository: Repository<Manga>,
+  ) {}
+
+  /**
+   * Candidats du catalogue local matchant les genres favoris de la biblio.
+   *
+   * Requête : genres non null, au moins un genre favori (`?|`), aucun genre
+   * NSFW, rating ≥ 7.0, hors bibliothèque, tri rating DESC LIMIT 300.
+   */
+  async findCandidates(
+    userMangas: UserManga[],
+    excludeMuIds: Set<string>,
+    maxCandidates = 200,
+  ): Promise<CatalogCandidate[]> {
+    const shares = this.computeGenreShares(userMangas);
+    if (shares.size === 0) return [];
+    const topGenres = Array.from(shares.keys());
+
+    const qb = this.mangaRepository
+      .createQueryBuilder('m')
+      .where('m.genres IS NOT NULL')
+      .andWhere('m.genres::jsonb ?| ARRAY[:...topGenres]', { topGenres })
+      .andWhere('NOT (m.genres::jsonb ?| ARRAY[:...nsfwGenres])', {
+        nsfwGenres: NSFW_GENRES,
+      })
+      .andWhere('m.rating >= :ratingFloor', {
+        ratingFloor: CatalogCandidateService.RATING_FLOOR,
+      });
+    if (excludeMuIds.size > 0) {
+      qb.andWhere('m.mu_id NOT IN (:...excludeMuIds)', {
+        excludeMuIds: Array.from(excludeMuIds),
+      });
+    }
+    const candidates = await qb
+      .orderBy('m.rating', 'DESC')
+      .limit(CatalogCandidateService.QUERY_LIMIT)
+      .getMany();
+
+    if (candidates.length === 0) return [];
+
+    const sourcesByGenre = this.buildSourcesByGenre(userMangas, topGenres);
+    const scored: CatalogCandidate[] = [];
+    for (const manga of candidates) {
+      const matched = (manga.genres ?? []).filter((g) => shares.has(g));
+      if (matched.length === 0) continue;
+      let genreScore = 0;
+      let dominantGenre = matched[0];
+      let bestShare = 0;
+      for (const genre of matched) {
+        const share = shares.get(genre) ?? 0;
+        genreScore += share;
+        if (share > bestShare) {
+          bestShare = share;
+          dominantGenre = genre;
+        }
+      }
+      const rating = Number(manga.rating) || 0;
+      const ratingBoost = Math.min(Math.max((rating - 6.5) / 3.5, 0), 1);
+      const score =
+        CatalogCandidateService.CATALOG_BASE_WEIGHT *
+        genreScore *
+        (0.5 + 0.5 * ratingBoost);
+      scored.push({
+        mu_id: manga.mu_id,
+        score,
+        sourceMuIds: sourcesByGenre.get(dominantGenre) ?? [],
+      });
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    this.logger.log(
+      `Catalogue : ${scored.length} candidat(s) pour genres [${topGenres.join(
+        ', ',
+      )}]`,
+    );
+    return scored.slice(0, maxCandidates);
+  }
+
+  /**
+   * Genres favoris de la biblio (pattern `computeGenreCounts` des stats) :
+   * top 5 par occurrences, share(g) = count(g) / totalOccurrences.
+   */
+  private computeGenreShares(userMangas: UserManga[]): Map<string, number> {
+    const counts = new Map<string, number>();
+    let total = 0;
+    for (const um of userMangas) {
+      for (const genre of um.manga?.genres ?? []) {
+        if (!genre) continue;
+        counts.set(genre, (counts.get(genre) ?? 0) + 1);
+        total += 1;
+      }
+    }
+    if (total === 0) return new Map();
+    const top = Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, CatalogCandidateService.TOP_GENRES);
+    return new Map(top.map(([genre, count]) => [genre, count / total]));
+  }
+
+  /**
+   * Pour chaque genre favori : les 2 mangas biblio au multiplicateur le
+   * plus élevé qui portent ce genre (pré-calcul, une passe par genre).
+   */
+  private buildSourcesByGenre(
+    userMangas: UserManga[],
+    genres: string[],
+  ): Map<string, string[]> {
+    const result = new Map<string, string[]>();
+    for (const genre of genres) {
+      const sources = userMangas
+        .filter((um) => (um.manga?.genres ?? []).includes(genre))
+        .sort((a, b) => this.computeMultiplier(b) - this.computeMultiplier(a))
+        .slice(0, CatalogCandidateService.SOURCES_PER_CANDIDATE)
+        .map((um) => um.manga.mu_id);
+      result.set(genre, sources);
+    }
+    return result;
+  }
+
+  /** Miroir de `RecommendationService.computeMultiplier` (voir doc statique). */
+  private computeMultiplier(um: UserManga): number {
+    const ratingMultiplier = um.user_rating > 0 ? um.user_rating / 5.0 : 1.0;
+    const statusMultiplier =
+      CatalogCandidateService.STATUS_MULTIPLIER[um.readingStatus] ?? 1.0;
+    const ageDays = (Date.now() - um.adding_date.getTime()) / 86_400_000;
+    const recencyMultiplier = Math.exp(
+      -ageDays / CatalogCandidateService.RECENCY_HALF_LIFE_DAYS,
+    );
+    return ratingMultiplier * statusMultiplier * recencyMultiplier;
+  }
+}

--- a/src/api/recommendations/recommendation.controller.ts
+++ b/src/api/recommendations/recommendation.controller.ts
@@ -32,7 +32,7 @@ export class RecommendationController {
     name: 'limit',
     required: false,
     type: Number,
-    description: 'Nombre max de recommandations (défaut : 50, max : 100)',
+    description: 'Nombre max de recommandations (défaut : 50, max : 500)',
   })
   @ApiQuery({
     name: 'offset',
@@ -107,7 +107,7 @@ export class RecommendationController {
     name: 'limit',
     required: false,
     type: Number,
-    description: 'Nombre max de pépites (défaut : 20, max : 100)',
+    description: 'Nombre max de pépites (défaut : 20, max : 500)',
   })
   @ApiResponse({
     status: 200,

--- a/src/api/recommendations/recommendation.module.ts
+++ b/src/api/recommendations/recommendation.module.ts
@@ -6,6 +6,7 @@ import { Manga } from '@/api/mangas/manga.entity';
 import { MangasModule } from '@/api/mangas/mangas.module';
 import { RecommendationService } from './recommendation.service';
 import { RecommendationController } from './recommendation.controller';
+import { CatalogCandidateService } from './catalog-candidate.service';
 import { RecoCacheModule } from './reco-cache.module';
 
 @Module({
@@ -17,7 +18,7 @@ import { RecoCacheModule } from './reco-cache.module';
     RecoCacheModule,
   ],
   controllers: [RecommendationController],
-  providers: [RecommendationService],
+  providers: [RecommendationService, CatalogCandidateService],
   exports: [RecommendationService],
 })
 export class RecommendationModule {}

--- a/src/api/recommendations/recommendation.service.spec.ts
+++ b/src/api/recommendations/recommendation.service.spec.ts
@@ -2,10 +2,15 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { RecommendationService } from './recommendation.service';
 import { RecoCacheService } from './reco-cache.service';
+import {
+  CatalogCandidate,
+  CatalogCandidateService,
+} from './catalog-candidate.service';
 import { UserManga } from '@/api/mangas/user-manga.entity';
 import { MangaRecommendation } from '@/api/mangas/manga-recommendation.entity';
 import { Manga } from '@/api/mangas/manga.entity';
 import { MangasService } from '@/api/mangas/mangas.service';
+import { MuRateLimitException } from '@/api/mangas/exceptions/mu-rate-limit.exception';
 import { ReadingStatus } from '@/api/library/reading-status.enum';
 
 /**
@@ -66,6 +71,7 @@ describe('RecommendationService', () => {
     fetchAndCacheRecommendations: jest.Mock;
     getCommunityRatings: jest.Mock;
   };
+  let catalogCandidates: { findCandidates: jest.Mock };
 
   beforeEach(async () => {
     userMangaRepo = { find: jest.fn().mockResolvedValue([]) };
@@ -79,6 +85,10 @@ describe('RecommendationService', () => {
       // Mock de l'enrichissement community rating (par défaut : map vide)
       getCommunityRatings: jest.fn().mockResolvedValue(new Map()),
     } as any;
+    // Catalogue local vide par défaut — les tests dédiés le peuplent.
+    catalogCandidates = {
+      findCandidates: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -93,10 +103,13 @@ describe('RecommendationService', () => {
         },
         { provide: getRepositoryToken(Manga), useValue: mangaRepo },
         { provide: MangasService, useValue: mangasService },
+        { provide: CatalogCandidateService, useValue: catalogCandidates },
       ],
     }).compile();
 
     service = module.get<RecommendationService>(RecommendationService);
+    // Neutralise les pauses inter-batch (batch délai/429 testés dédiés).
+    service.sleep = jest.fn().mockResolvedValue(undefined);
   });
 
   it('utilise le fallback cold start si la bibliothèque est vide', async () => {
@@ -230,9 +243,10 @@ describe('RecommendationService', () => {
     expect(result[0].largeCoverUrl).toBe('https://cdn/2000-m.jpg');
   });
 
-  it('limite à MAX_RECOS_PER_SOURCE pour la diversité', async () => {
-    // 4 mangas en biblio, chacun avec 45 recos disjointes : pool initial = 4×40 = 160,
-    // au-dessus de MIN_POOL_BEFORE_RELAX (50) donc le cap=40 reste appliqué.
+  it('limite à MAX_RECOS_PER_SOURCE pour la diversité (pool ≥ 150 → catalogue non sollicité)', async () => {
+    // 4 mangas en biblio, chacun avec 45 recos disjointes : pool = 4×40 = 160,
+    // au-dessus de CATALOG_MIN_POOL (150) donc le catalogue local n'est pas
+    // interrogé et le cap=40 par source reste appliqué.
     const userMangas = Array.from({ length: 4 }, (_, i) =>
       makeUserManga({
         id: i + 1,
@@ -273,6 +287,8 @@ describe('RecommendationService', () => {
     const muIds = new Set(result.map((r) => r.muId));
     expect(muIds.has(2039)).toBe(true); // Top 40 de la source 1000
     expect(muIds.has(2040)).toBe(false); // 41e reco de la source 1000 → tronquée
+    // Seuil : pool (160) ≥ CATALOG_MIN_POOL (150) → catalogue non appelé.
+    expect(catalogCandidates.findCandidates).not.toHaveBeenCalled();
   });
 
   it('sert les recos depuis le cache user-level au 2e appel (US-4)', async () => {
@@ -735,5 +751,175 @@ describe('RecommendationService', () => {
     expect(mangasService.fetchAndCacheRecommendations).toHaveBeenCalledWith(
       1001,
     );
+  });
+
+  describe('catalogue local (CATALOG_MIN_POOL)', () => {
+    function makeCandidate(
+      mu_id: string,
+      score: number,
+      sourceMuIds: string[] = ['1000'],
+    ): CatalogCandidate {
+      return { mu_id, score, sourceMuIds };
+    }
+
+    it('fusionne les candidats catalogue sous le seuil : tri global, MU prime (pas d’addition), biblio exclue', async () => {
+      userMangaRepo.find.mockResolvedValue([
+        makeUserManga({ manga: makeManga({ mu_id: '1000' }) }),
+      ]);
+      // 3 recos MU en cache — scores ≈ weight × 1.2 (reading récent).
+      mangasService.getCachedRecommendations.mockResolvedValue([
+        makeReco('1000', '2000', 10),
+        makeReco('1000', '2001', 7),
+        makeReco('1000', '2002', 5),
+      ]);
+      // Catalogue : 1 nouveau candidat, 1 collision avec une reco MU (2002,
+      // score volontairement énorme), 1 candidat déjà en biblio (1000).
+      catalogCandidates.findCandidates.mockResolvedValue([
+        makeCandidate('3000', 4.5, ['1000']),
+        makeCandidate('2002', 999),
+        makeCandidate('1000', 999),
+      ]);
+      mangaRepo.find.mockImplementation(({ where }) => {
+        const ids = (where as any).mu_id._value;
+        return Promise.resolve(
+          ids.map((id: string) =>
+            makeManga({ mu_id: id, title: `Manga ${id}` }),
+          ),
+        );
+      });
+
+      const result = await service.buildUserRecommendations(42, 50, 0);
+
+      // findCandidates reçoit la biblio en exclusion stricte.
+      expect(catalogCandidates.findCandidates).toHaveBeenCalledTimes(1);
+      const excludeArg = catalogCandidates.findCandidates.mock
+        .calls[0][1] as Set<string>;
+      expect(excludeArg.has('1000')).toBe(true);
+
+      const ids = result.map((r) => r.muId);
+      // Biblio exclue même si le catalogue la propose.
+      expect(ids).not.toContain(1000);
+      // Fusion triée : le candidat catalogue s'intercale selon son score et
+      // 2002 GARDE son score MU (une addition/écrasement le mettrait en tête).
+      expect(ids).toEqual([2000, 2001, 2002, 3000]);
+      // Explicabilité : recommendedBecauseOf depuis sourceMuIds.
+      const dto3000 = result.find((r) => r.muId === 3000);
+      expect(dto3000!.recommendedBecauseOf).toContain('Manga 1000');
+    });
+
+    it('ne sollicite pas le catalogue quand le pool MU atteint le seuil (voir test MAX_RECOS_PER_SOURCE)', async () => {
+      // Pool vide + biblio vide → cold start, catalogue jamais consulté.
+      userMangaRepo.find.mockResolvedValue([]);
+      userMangaRepo.createQueryBuilder = jest.fn(() => ({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        having: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      })) as any;
+      mangaRepo.createQueryBuilder = jest.fn(() => ({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      })) as any;
+
+      await service.buildUserRecommendations(42);
+      expect(catalogCandidates.findCandidates).not.toHaveBeenCalled();
+    });
+
+    it('by-genre bénéficie aussi du complément catalogue (via computeScoreMap)', async () => {
+      userMangaRepo.find.mockResolvedValue([
+        makeUserManga({ manga: makeManga({ mu_id: '1000' }) }),
+      ]);
+      mangasService.getCachedRecommendations.mockResolvedValue([
+        makeReco('1000', '2000', 10),
+      ]);
+      catalogCandidates.findCandidates.mockResolvedValue([
+        makeCandidate('3000', 4.5, ['1000']),
+      ]);
+      mangaRepo.find.mockImplementation(({ where }) => {
+        const ids = (where as any).mu_id._value;
+        return Promise.resolve(
+          ids.map((id: string) =>
+            makeManga({ mu_id: id, title: `Manga ${id}`, genres: ['Action'] }),
+          ),
+        );
+      });
+
+      const result = await service.buildUserRecommendationsByGenre(42, 5, 10);
+      expect(catalogCandidates.findCandidates).toHaveBeenCalledTimes(1);
+      expect(result['Action'].map((d) => d.muId)).toEqual([2000, 3000]);
+    });
+  });
+
+  describe('fetch bloquant batché (délai / 429)', () => {
+    function makeLibrary(size: number): UserManga[] {
+      return Array.from({ length: size }, (_, i) =>
+        makeUserManga({
+          id: i + 1,
+          manga: makeManga({ id: i + 1, mu_id: String(1000 + i) }),
+        }),
+      );
+    }
+
+    beforeEach(() => {
+      mangasService.getCachedRecommendations.mockResolvedValue([]);
+      mangaRepo.find.mockImplementation(({ where }) => {
+        const ids = (where as any).mu_id._value;
+        return Promise.resolve(
+          ids.map((id: string) =>
+            makeManga({ mu_id: id, title: `Manga ${id}` }),
+          ),
+        );
+      });
+    });
+
+    it('pause 1 s entre deux batches de 5 fetches MU', async () => {
+      userMangaRepo.find.mockResolvedValue(makeLibrary(10));
+      mangasService.fetchAndCacheRecommendations.mockImplementation(
+        (muId: number) =>
+          Promise.resolve([makeReco(String(muId), String(muId + 1000), 5)]),
+      );
+      const sleepSpy = jest.fn().mockResolvedValue(undefined);
+      service.sleep = sleepSpy;
+
+      await service.buildUserRecommendations(42, 50, 0);
+
+      // 10 mangas → 2 batches de 5 → une seule pause, de 1000 ms.
+      expect(sleepSpy).toHaveBeenCalledTimes(1);
+      expect(sleepSpy).toHaveBeenCalledWith(1000);
+    });
+
+    it('MuRateLimitException (429) dans un batch → pause 5 s avant le batch suivant', async () => {
+      userMangaRepo.find.mockResolvedValue(makeLibrary(10));
+      mangasService.fetchAndCacheRecommendations.mockImplementation(
+        (muId: number) => {
+          // Tout le 1er batch (1000-1004) est rate-limité.
+          if (muId < 1005) {
+            return Promise.reject(new MuRateLimitException(muId));
+          }
+          return Promise.resolve([
+            makeReco(String(muId), String(muId + 1000), 5),
+          ]);
+        },
+      );
+      const sleepSpy = jest.fn().mockResolvedValue(undefined);
+      service.sleep = sleepSpy;
+
+      const result = await service.buildUserRecommendations(42, 50, 0);
+
+      expect(sleepSpy).toHaveBeenCalledTimes(1);
+      expect(sleepSpy).toHaveBeenCalledWith(5000);
+      // Le 2e batch a été traité malgré le 429 du 1er.
+      expect(mangasService.fetchAndCacheRecommendations).toHaveBeenCalledWith(
+        1009,
+      );
+      expect(result.map((r) => r.muId)).toEqual(
+        expect.arrayContaining([2005, 2006, 2007, 2008, 2009]),
+      );
+    });
   });
 });

--- a/src/api/recommendations/recommendation.service.ts
+++ b/src/api/recommendations/recommendation.service.ts
@@ -6,7 +6,12 @@ import { MangaRecommendation } from '@/api/mangas/manga-recommendation.entity';
 import { Manga } from '@/api/mangas/manga.entity';
 import { MangasService } from '@/api/mangas/mangas.service';
 import { MangaQuickViewDto } from '@/api/mangas/dto/manga-quick-view.dto';
+import { MuRateLimitException } from '@/api/mangas/exceptions/mu-rate-limit.exception';
 import { RecoCacheService } from './reco-cache.service';
+import {
+  CatalogCandidate,
+  CatalogCandidateService,
+} from './catalog-candidate.service';
 
 /**
  * Entrée scorée pour un manga candidat.
@@ -49,24 +54,18 @@ export class RecommendationService {
    * Les recos étant intrinsèquement subjectives, on préfère un pool large
    * + un tri par score que de filtrer en amont.
    *
-   * Cap "soft" : si le pool final est trop maigre, on relaxe via
-   * `ADAPTIVE_FALLBACK_CAP` (cf. `scoreRecos`).
+   * Pool trop maigre malgré tout → complété par le catalogue local
+   * (cf. `CATALOG_MIN_POOL` / `augmentWithCatalog`), qui a remplacé
+   * l'ancien mécanisme de relax du cap (no-op en pratique).
    */
   private static readonly MAX_RECOS_PER_SOURCE = 40;
 
   /**
-   * Cap secondaire utilisé en repli quand le pool ne dépasse pas
-   * `MIN_POOL_BEFORE_RELAX`. On préfère plus de recos potentiellement
-   * redondantes que zéro reco du tout. (60 → 80 le 2026-06-11, suit le
-   * bump du cap principal.)
+   * Seuil de pool sous lequel le scoring MU est complété par des candidats
+   * du catalogue local (`CatalogCandidateService.findCandidates`). Le merge
+   * n'additionne JAMAIS : un candidat déjà scoré par MU garde son score MU.
    */
-  private static readonly ADAPTIVE_FALLBACK_CAP = 80;
-
-  /**
-   * Si la liste de candidats finale a moins de `MIN_POOL_BEFORE_RELAX`
-   * entrées, on rejoue le scoring avec `ADAPTIVE_FALLBACK_CAP`.
-   */
-  private static readonly MIN_POOL_BEFORE_RELAX = 50;
+  private static readonly CATALOG_MIN_POOL = 150;
 
   /** Limite max de la pagination. **2026-05-19** : 100 → 500. */
   private static readonly MAX_LIMIT = 500;
@@ -96,6 +95,16 @@ export class RecommendationService {
   /** Timeout par fetch MU (ms). */
   private static readonly FETCH_TIMEOUT_MS = 15000;
 
+  /** Pause entre deux batches de fetch MU bloquants (ms). */
+  private static readonly BATCH_DELAY_MS = 1000;
+
+  /** Pause après un 429 MU avant le batch suivant (ms). */
+  private static readonly RATE_LIMIT_DELAY_MS = 5000;
+
+  /** Injectable pour les tests (évite les vrais timers). */
+  sleep: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
   constructor(
     @InjectRepository(UserManga)
     private readonly userMangaRepository: Repository<UserManga>,
@@ -105,6 +114,7 @@ export class RecommendationService {
     private readonly mangaRepository: Repository<Manga>,
     private readonly mangasService: MangasService,
     private readonly recoCache: RecoCacheService,
+    private readonly catalogCandidates: CatalogCandidateService,
   ) {}
 
   /**
@@ -300,8 +310,8 @@ export class RecommendationService {
       if (uncachedIds.length > 0) {
         this.fetchUncachedInBackground(uncachedIds);
       }
-      // Adaptive : si pool trop maigre, relax le cap par source.
-      await this.relaxIfPoolTooSmall(userMangas, libraryMuIds, scoreMap);
+      // Pool trop maigre → complément depuis le catalogue local.
+      await this.augmentWithCatalog(userMangas, libraryMuIds, scoreMap);
       const result = await this.buildDtoFromScoreMap(
         scoreMap,
         effectiveLimit,
@@ -316,44 +326,10 @@ export class RecommendationService {
     this.logger.log(
       `Cache vide pour userId=${userId}, fetch MU pour ${userMangas.length} manga(s)`,
     );
+    await this.fetchAndScoreBlocking(userMangas, libraryMuIds, scoreMap);
 
-    for (
-      let i = 0;
-      i < userMangas.length;
-      i += RecommendationService.BATCH_SIZE
-    ) {
-      const batch = userMangas.slice(i, i + RecommendationService.BATCH_SIZE);
-      await Promise.all(
-        batch.map(async (um) => {
-          const muId = Number(um.manga.mu_id);
-          let recos: MangaRecommendation[];
-          try {
-            recos = await Promise.race([
-              this.mangasService.fetchAndCacheRecommendations(muId),
-              new Promise<MangaRecommendation[]>((_, reject) =>
-                setTimeout(
-                  () => reject(new Error('timeout')),
-                  RecommendationService.FETCH_TIMEOUT_MS,
-                ),
-              ),
-            ]);
-          } catch (err) {
-            this.logger.warn(`Reco fetch timeout/erreur pour ${muId}: ${err}`);
-            return;
-          }
-          this.scoreRecos(
-            um.manga.mu_id,
-            this.computeMultiplier(um),
-            recos,
-            libraryMuIds,
-            scoreMap,
-          );
-        }),
-      );
-    }
-
+    await this.augmentWithCatalog(userMangas, libraryMuIds, scoreMap);
     if (scoreMap.size === 0) return [];
-    await this.relaxIfPoolTooSmall(userMangas, libraryMuIds, scoreMap);
     const result = await this.buildDtoFromScoreMap(
       scoreMap,
       effectiveLimit,
@@ -405,17 +381,37 @@ export class RecommendationService {
 
     if (scoreMap.size > 0) {
       if (uncachedIds.length > 0) this.fetchUncachedInBackground(uncachedIds);
-      await this.relaxIfPoolTooSmall(userMangas, libraryMuIds, scoreMap);
+      await this.augmentWithCatalog(userMangas, libraryMuIds, scoreMap);
       return scoreMap;
     }
 
     // Cache vide : fetch bloquant batché
+    await this.fetchAndScoreBlocking(userMangas, libraryMuIds, scoreMap);
+    await this.augmentWithCatalog(userMangas, libraryMuIds, scoreMap);
+    return scoreMap;
+  }
+
+  /**
+   * Fetch MU bloquant batché (batch = BATCH_SIZE, timeout par fetch) qui
+   * alimente le scoreMap — factorisation des 2 anciennes boucles dupliquées
+   * de `buildUserRecommendations` / `computeScoreMap`.
+   *
+   * Rythme : pause `BATCH_DELAY_MS` (1 s) entre les batches ; si MU répond
+   * 429 (`MuRateLimitException` rethrow par `fetchAndCacheRecommendations`),
+   * la pause passe à `RATE_LIMIT_DELAY_MS` (5 s) avant le batch suivant.
+   */
+  private async fetchAndScoreBlocking(
+    userMangas: UserManga[],
+    libraryMuIds: Set<string>,
+    scoreMap: Map<string, ScoredEntry>,
+  ): Promise<void> {
     for (
       let i = 0;
       i < userMangas.length;
       i += RecommendationService.BATCH_SIZE
     ) {
       const batch = userMangas.slice(i, i + RecommendationService.BATCH_SIZE);
+      let rateLimited = false;
       await Promise.all(
         batch.map(async (um) => {
           const muId = Number(um.manga.mu_id);
@@ -430,7 +426,9 @@ export class RecommendationService {
                 ),
               ),
             ]);
-          } catch {
+          } catch (err) {
+            if (err instanceof MuRateLimitException) rateLimited = true;
+            this.logger.warn(`Reco fetch timeout/erreur pour ${muId}: ${err}`);
             return;
           }
           this.scoreRecos(
@@ -442,11 +440,62 @@ export class RecommendationService {
           );
         }),
       );
+      const hasNextBatch =
+        i + RecommendationService.BATCH_SIZE < userMangas.length;
+      if (hasNextBatch) {
+        await this.sleep(
+          rateLimited
+            ? RecommendationService.RATE_LIMIT_DELAY_MS
+            : RecommendationService.BATCH_DELAY_MS,
+        );
+      }
     }
-    if (scoreMap.size > 0) {
-      await this.relaxIfPoolTooSmall(userMangas, libraryMuIds, scoreMap);
+  }
+
+  /**
+   * Complète le scoreMap avec des candidats du catalogue local quand le
+   * scoring MU remonte moins de `CATALOG_MIN_POOL` entrées.
+   *
+   * Merge SANS addition : un candidat déjà scoré par MU garde son score MU
+   * (les recos humaines priment sur l'affinité de genres). L'exclusion
+   * stricte de la bibliothèque est conservée (défense en profondeur ici,
+   * `findCandidates` exclut déjà via `excludeMuIds`).
+   */
+  private async augmentWithCatalog(
+    userMangas: UserManga[],
+    libraryMuIds: Set<string>,
+    scoreMap: Map<string, ScoredEntry>,
+  ): Promise<void> {
+    if (scoreMap.size >= RecommendationService.CATALOG_MIN_POOL) return;
+
+    let candidates: CatalogCandidate[];
+    try {
+      candidates = await this.catalogCandidates.findCandidates(
+        userMangas,
+        libraryMuIds,
+      );
+    } catch (err) {
+      this.logger.warn(`Candidats catalogue indisponibles: ${err}`);
+      return;
     }
-    return scoreMap;
+    if (candidates.length === 0) return;
+
+    let added = 0;
+    for (const candidate of candidates) {
+      if (scoreMap.has(candidate.mu_id)) continue; // MU prime — pas d'addition
+      if (libraryMuIds.has(candidate.mu_id)) continue;
+      const sources = new Map<string, number>();
+      for (const sourceMuId of candidate.sourceMuIds) {
+        sources.set(sourceMuId, candidate.score);
+      }
+      scoreMap.set(candidate.mu_id, { score: candidate.score, sources });
+      added += 1;
+    }
+    if (added > 0) {
+      this.logger.log(
+        `Pool maigre — ${added} candidat(s) catalogue ajoutés (pool=${scoreMap.size})`,
+      );
+    }
   }
 
   /**
@@ -625,9 +674,7 @@ export class RecommendationService {
 
   /**
    * Applique les recos d'un manga source au scoreMap, en limitant la
-   * contribution à `perSourceCap` (par défaut MAX_RECOS_PER_SOURCE) pour
-   * la diversité. Permettre l'override est utilisé par le replay adaptatif
-   * (cf. `relaxIfPoolTooSmall`).
+   * contribution à `MAX_RECOS_PER_SOURCE` pour la diversité.
    */
   private scoreRecos(
     sourceMuId: string,
@@ -635,11 +682,10 @@ export class RecommendationService {
     recos: MangaRecommendation[],
     libraryMuIds: Set<string>,
     scoreMap: Map<string, ScoredEntry>,
-    perSourceCap: number = RecommendationService.MAX_RECOS_PER_SOURCE,
   ): void {
     const topRecos = [...recos]
       .sort((a, b) => b.weight - a.weight)
-      .slice(0, perSourceCap);
+      .slice(0, RecommendationService.MAX_RECOS_PER_SOURCE);
 
     for (const reco of topRecos) {
       // Exclusion stricte des mangas déjà en biblio : l'user ne veut pas
@@ -659,57 +705,6 @@ export class RecommendationService {
         (entry.sources.get(sourceMuId) ?? 0) + contribution,
       );
     }
-  }
-
-  /**
-   * Si le scoreMap a moins de `MIN_POOL_BEFORE_RELAX` entrées, rejoue le
-   * scoring avec `ADAPTIVE_FALLBACK_CAP` pour repêcher des candidats
-   * supplémentaires (long tail). On préfère un pool plus large
-   * potentiellement redondant à un pool quasi-vide.
-   *
-   * Effet : un user avec 1-2 mangas en biblio aura quand même un volume
-   * de recos décent (jusqu'à 25 recos par manga source au lieu de 5).
-   */
-  private async relaxIfPoolTooSmall(
-    userMangas: UserManga[],
-    libraryMuIds: Set<string>,
-    scoreMap: Map<string, ScoredEntry>,
-  ): Promise<void> {
-    if (scoreMap.size >= RecommendationService.MIN_POOL_BEFORE_RELAX) return;
-
-    this.logger.log(
-      `Pool maigre (${scoreMap.size} candidats) — relax cap ${RecommendationService.MAX_RECOS_PER_SOURCE} → ${RecommendationService.ADAPTIVE_FALLBACK_CAP}`,
-    );
-
-    // On rejoue uniquement avec les recos en cache (pas de re-fetch MU :
-    // si le cache est vide, la première passe l'aurait déjà rempli ou
-    // marqué uncached, donc rien à gagner à reposer la question).
-    await Promise.all(
-      userMangas.map(async (um) => {
-        const muId = Number(um.manga.mu_id);
-        const cached = await this.mangasService.getCachedRecommendations(muId);
-        if (cached.length === 0) return;
-        // ATTENTION : rejouer scoreRecos avec un cap plus large RE-AJOUTE les
-        // contributions des recos déjà comptabilisées dans la 1ère passe.
-        // Pour éviter le double-count, on ne scoore QUE les recos au-delà
-        // du cap de base.
-        const extraRecos = [...cached]
-          .sort((a, b) => b.weight - a.weight)
-          .slice(
-            RecommendationService.MAX_RECOS_PER_SOURCE,
-            RecommendationService.ADAPTIVE_FALLBACK_CAP,
-          );
-        this.scoreRecos(
-          um.manga.mu_id,
-          this.computeMultiplier(um),
-          extraRecos,
-          libraryMuIds,
-          scoreMap,
-          // Cap = +∞ ici (les recos sont déjà tronquées au-dessus).
-          extraRecos.length,
-        );
-      }),
-    );
   }
 
   /**

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -21,6 +22,8 @@ const envFilePath: string = getEnvPath(`${__dirname}/common/envs`);
     // pour des limites plus strictes (5–10 req/min).
     // Cf. CLAUDE.md « Sécurité non-négociable ».
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
+    // Crons applicatifs (sync nightly du catalogue MU — CatalogSyncService).
+    ScheduleModule.forRoot(),
     ApiModule,
     HealthModule,
   ],

--- a/src/common/envs/template.env
+++ b/src/common/envs/template.env
@@ -19,6 +19,29 @@ ENABLE_DEBUG_MESSAGES_FOR_API_CLIENT=
 DISABLE_ERROR_MESSAGES_FOR_API_CLIENT=
 TYPEORM_DEBUG_LOGGING=
 
+# ─── Traduction des descriptions (serveur) ──────────────────────
+# Clé DeepL API Free (optionnelle) : si absente, fallback automatique sur
+# l'endpoint Google gtx sans clé. https://www.deepl.com/pro-api
+DEEPL_API_KEY=
+# Timeout dur (ms) de la traduction synchrone au 1er visiteur ; au-delà,
+# la description originale est renvoyée et la traduction se termine en
+# arrière-plan pour le visiteur suivant.
+TRANSLATION_TIMEOUT_MS=4000
+
+# ─── Sync nightly du catalogue MangaUpdates ─────────────────────
+# Cron 03:30 + jitter 0-15 min (CatalogSyncService). Défauts appliqués si
+# les variables sont absentes (ENABLED est forcé à false si NODE_ENV=test).
+# CATALOG_SYNC_MAX_PAGES : pages max de la passe rating (100 titres/page).
+# CATALOG_SYNC_PAGES_PER_RUN : budget de pages par nuit (toutes passes).
+# CATALOG_SYNC_DELAY_MS : délai entre 2 appels MU (2000 ms = 30 req/min).
+# CATALOG_SYNC_HYDRATION_BUDGET : appels détail MU max/nuit pour hydrater
+# les genres manquants (stubs de recos inclus).
+CATALOG_SYNC_ENABLED=true
+CATALOG_SYNC_MAX_PAGES=50
+CATALOG_SYNC_PAGES_PER_RUN=60
+CATALOG_SYNC_DELAY_MS=2000
+CATALOG_SYNC_HYDRATION_BUDGET=200
+
 # ─── SMTP (Brevo) ─────────────────────────────────────────────────
 # Voir https://www.brevo.com → SMTP & API → Paramètres SMTP
 SMTP_HOST=smtp-relay.brevo.com

--- a/src/migrations/1753100000000-CreateMangaChapterReport.ts
+++ b/src/migrations/1753100000000-CreateMangaChapterReport.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+/**
+ * Chantier A — Crée la table `manga_chapter_report` : signalement par un
+ * user que le manga a plus de chapitres que le `manga.total_chapters` connu
+ * (la regex sur le status MangaUpdates sous-estime souvent le vrai total).
+ *
+ * - La ligne est l'override PAR USER : total effectif =
+ *   `max(manga.total_chapters, reported_total)`.
+ * - Unicité (user_id, manga_id) : un report actif par user et par manga —
+ *   un nouveau report écrase l'ancien (upsert `ON CONFLICT DO UPDATE`,
+ *   d'où l'index UNIQUE requis sur ces deux colonnes).
+ * - Consolidation : ≥ 2 users concordants → bump du total officiel + purge
+ *   des reports couverts (voir `ChapterReportService`).
+ *
+ * Pas de migration de data — la table démarre vide.
+ */
+export class CreateMangaChapterReport1753100000000
+  implements MigrationInterface
+{
+  name = 'CreateMangaChapterReport1753100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('manga_chapter_report');
+    if (exists) return;
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'manga_chapter_report',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'user_id', type: 'int', isNullable: false },
+          { name: 'manga_id', type: 'bigint', isNullable: false },
+          { name: 'reported_total', type: 'int', isNullable: false },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['user_id'],
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['manga_id'],
+            referencedTableName: 'manga',
+            referencedColumnNames: ['mu_id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+        indices: [
+          {
+            name: 'UQ_chapter_report_user_manga',
+            columnNames: ['user_id', 'manga_id'],
+            isUnique: true,
+          },
+          {
+            name: 'IDX_chapter_report_manga',
+            columnNames: ['manga_id'],
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('manga_chapter_report');
+    if (exists) await queryRunner.dropTable('manga_chapter_report');
+  }
+}

--- a/src/migrations/1753200000000-CreateMangaTranslationTable.ts
+++ b/src/migrations/1753200000000-CreateMangaTranslationTable.ts
@@ -1,0 +1,103 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+/**
+ * Chantier A (traductions serveur) — Crée la table `manga_translation` :
+ * cache des descriptions traduites par (manga, langue).
+ *
+ * - Unicité (mu_id, language) : une seule traduction par manga et par
+ *   langue — l'upsert `ON CONFLICT DO UPDATE` du
+ *   `DescriptionTranslationService` s'appuie sur cet index UNIQUE.
+ * - `source_hash` (sha256 hex de la description MU) pilote la
+ *   re-traduction : hash différent → re-traduire, hash égal → hit.
+ * - Pas de FK vers `manga` : le détail est proxifié live depuis MU et le
+ *   manga peut ne pas encore exister en base au moment de la traduction
+ *   (même choix que `manga_recommendation`).
+ *
+ * Pas de migration de data — la table démarre vide.
+ */
+export class CreateMangaTranslationTable1753200000000
+  implements MigrationInterface
+{
+  name = 'CreateMangaTranslationTable1753200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('manga_translation');
+    if (exists) return;
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'manga_translation',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'mu_id',
+            type: 'bigint',
+            isNullable: false,
+          },
+          {
+            name: 'language',
+            type: 'varchar',
+            length: '5',
+            isNullable: false,
+          },
+          {
+            name: 'source_hash',
+            type: 'varchar',
+            length: '64',
+            isNullable: false,
+          },
+          {
+            name: 'translated_description',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'manga_translation',
+      new TableIndex({
+        name: 'IDX_manga_translation_mu_lang_unique',
+        columnNames: ['mu_id', 'language'],
+        isUnique: true,
+      }),
+    );
+
+    // Index secondaire pour "toutes les traductions d'un manga"
+    await queryRunner.createIndex(
+      'manga_translation',
+      new TableIndex({
+        name: 'IDX_manga_translation_mu',
+        columnNames: ['mu_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('manga_translation');
+    if (!exists) return;
+    await queryRunner.dropIndex(
+      'manga_translation',
+      'IDX_manga_translation_mu',
+    );
+    await queryRunner.dropIndex(
+      'manga_translation',
+      'IDX_manga_translation_mu_lang_unique',
+    );
+    await queryRunner.dropTable('manga_translation', true);
+  }
+}

--- a/src/migrations/1753300000000-CreateCatalogSyncState.ts
+++ b/src/migrations/1753300000000-CreateCatalogSyncState.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+/**
+ * Catalogue local nightly — crée la table `catalog_sync_state` : curseur
+ * persistant des passes de synchronisation du catalogue MangaUpdates
+ * (CatalogSyncService, cron 03:30).
+ *
+ * - Une ligne par job (`catalog:rating`, `catalog:week_pos`, `hydration`).
+ * - `last_completed_page` permet la reprise après un arrêt partiel
+ *   (rate-limit MU, budget de pages épuisé, redémarrage).
+ * - Additive et guardée par `hasTable` → sûre avec `migrationsRun` en prod.
+ */
+export class CreateCatalogSyncState1753300000000 implements MigrationInterface {
+  name = 'CreateCatalogSyncState1753300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('catalog_sync_state');
+    if (exists) return;
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'catalog_sync_state',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'job_name',
+            type: 'varchar',
+            isNullable: false,
+            isUnique: true,
+          },
+          {
+            name: 'last_completed_page',
+            type: 'int',
+            default: 0,
+            isNullable: false,
+          },
+          { name: 'total_pages', type: 'int', isNullable: true },
+          { name: 'last_run_at', type: 'timestamptz', isNullable: true },
+          { name: 'last_run_status', type: 'varchar', isNullable: true },
+          {
+            name: 'consecutive_failures',
+            type: 'int',
+            default: 0,
+            isNullable: false,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const exists = await queryRunner.hasTable('catalog_sync_state');
+    if (exists) await queryRunner.dropTable('catalog_sync_state');
+  }
+}


### PR DESCRIPTION
## Trois chantiers (issus de la session produit du 2026-07-07)

### 📖 Chapitres bloqués + historique vide
- **Signalement « plus de chapitres »** : `POST /library/:muId/report-chapters` (sous-controller dédié, **throttle par utilisateur** via `UserThrottlerGuard`, 10/h). Le rapporteur est débloqué immédiatement (le cap 406 s'applique au **total effectif** `max(total officiel, report)`, borné +200). Consolidation communautaire : **≥ 2 utilisateurs distincts** concordants → `manga.total_chapters` bumpé au `MIN` des concordants en `GREATEST` ; purge des reports quand MU rattrape.
- **`total_chapters` monotone croissant** : `GREATEST` inconditionnel dans `getMangaDetails` et `checkManga` — un refresh MU ne fait plus régresser un total (invariant A-5, cf. `decisions.md`).
- **Historique réparé** : le compteur manuel (`PUT /library/chapter`) journalise désormais chaque chapitre dans `user_manga_chapter_log` (backfill transactionnel, cap 500, chunks 100, fenêtre de dédup 10 min qui **rafraîchit** `scrollPosition`/`isBonus`). Web et mobile couverts.

### 🌍 Traductions serveur des descriptions
- Table `manga_translation` (`(mu_id, language)` unique, `source_hash` sha256 → re-traduction seulement si la description MU change). `DescriptionTranslationService` : providers **DeepL** (si `DEEPL_API_KEY`) → **gtx** fallback, dédup in-flight, timeout 4 s + upsert en arrière-plan, **stale-while-revalidate** + negative-cache 5 min. `GET /mangas/:id` lit `Accept-Language` → champ **additif** `translated_description` (en = passthrough, contrat rétrocompatible).

### 🔮 Catalogue nightly + recos élargies
- `@nestjs/schedule` : `CatalogSyncService` (@Cron 03:30 + jitter) pagine les populaires MU (perpage 100, 2 s/appel = 30 req/min, backoff 429 5/10/20/40 s, curseur de reprise `catalog_sync_state`, upsert **null-safe** par lots, hydratation genres 200/nuit) → ~5000 titres. Arrêt propre `partial` sur erreur DB.
- `CatalogCandidateService` : quand le pool de recos MU < 150, complète par les **genres favoris** depuis le catalogue local (rating ≥ 7, NSFW exclus, biblio exclue). Suppression du relax adaptatif (no-op prouvé). Fetch à froid : délai 1 s + `MuRateLimitException` (429 ne remonte plus au client).

## Migrations (additives)
`1753100000000` (manga_chapter_report), `1753200000000` (manga_translation), `1753300000000` (catalog_sync_state) — **appliquées et vérifiées sur un vrai Postgres 16**.

## Validation
- `npx jest` : **143/143**. `npm run build` : OK. ESLint : 0 erreur.
- **E2E local (Postgres réel)** : 13/13 — bornes report, consolidation 2 users → bump GREATEST à 90, déblocage compteur, backfill 90 lignes `chapter_log`, historique `/user/stats` non vide.
- Revue adversariale (3 relecteurs) passée ; 6 findings corrigés dans le commit `fix(api)`.

## ⚠️ Déploiement
- **Déployer cette API AVANT l'app** ([manga_tracker PR à suivre]) : les nouveaux champs/routes sont additifs ; le vieil APK 0.12.0 continue de fonctionner (GREATEST = total qui monte, transparent).
- **Aucune variable d'env nouvelle obligatoire** : `DEEPL_API_KEY` optionnelle (fallback gtx), `TRANSLATION_TIMEOUT_MS`/`CATALOG_SYNC_*` ont des défauts. `CATALOG_SYNC_ENABLED` défaut `true` → le cron nocturne démarrera (30 req/min max, fenêtre 03:30) — mettre à `false` si tu veux l'activer plus tard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
